### PR TITLE
47899-update-target-links-two-pages

### DIFF
--- a/Web/Edubase.Web.UI/403.html
+++ b/Web/Edubase.Web.UI/403.html
@@ -184,8 +184,10 @@
                     <h2 class="govuk-visually-hidden">Support links</h2>
                     <ul class="govuk-footer__inline-list">
                         <li class="govuk-footer__inline-list-item">
-                            <a href="https://form.education.gov.uk/service/Data-collections-service-request-form"
-                               target="_blank" rel="noreferrer noopener" class="govuk-footer__link">Contact</a>
+                            <a class="govuk-footer__link" href="/Contact">Contact</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="/glossary">Glossary</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
                             <a class="govuk-footer__link" href="/glossary">Glossary</a>

--- a/Web/Edubase.Web.UI/404.html
+++ b/Web/Edubase.Web.UI/404.html
@@ -168,8 +168,7 @@
                         <h2 class="govuk-visually-hidden">Support links</h2>
                         <ul class="govuk-footer__inline-list">
                             <li class="govuk-footer__inline-list-item">
-                                <a href="https://form.education.gov.uk/service/Data-collections-service-request-form"
-                                   target="_blank" rel="noreferrer noopener" class="govuk-footer__link">Contact</a>
+                                <a class="govuk-footer__link" href="/Contact">Contact</a>
                             </li>
                             <li class="govuk-footer__inline-list-item">
                                 <a class="govuk-footer__link" href="/glossary">Glossary</a>


### PR DESCRIPTION
Two of the static pages had an obsolete link to the contact section, this has been updated.