### PR TITLE
48089 - added top id to body and tweaked back-to-top links

### DIFF
--- a/Web/Edubase.Web.UI/App_Code/helpers.cshtml
+++ b/Web/Edubase.Web.UI/App_Code/helpers.cshtml
@@ -1,5 +1,5 @@
-﻿@helper BackToTopLink() {
-    <a class="back-to-top-link" href="#main-content">
+@helper BackToTopLink() {
+    <a class="back-to-top-link" href="#top">
         <svg role="presentation" focusable="false" class="back-to-top-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
             <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
         </svg>

--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/GiasAccordionExtensions.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/GiasAccordionExtensions.js
@@ -13,7 +13,7 @@ const giasAccordionExtensions = function(){
       .insertAfter(accordion);
 
 
-    const $scrollBtn = $(footerControls).prepend('<a href="#main-content" class="gias-scroll-to-top back-to-top-link"><svg role="presentation" focusable="false" class="back-to-top-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">\n' +
+    const $scrollBtn = $(footerControls).prepend('<a href="#top" class="gias-scroll-to-top back-to-top-link"><svg role="presentation" focusable="false" class="back-to-top-icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">\n' +
       '            <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>\n' +
       '        </svg> Back to top</a>');
 
@@ -33,10 +33,12 @@ const giasAccordionExtensions = function(){
       }, 0);
     });
 
-    $scrollBtn.on('click', function(e) {
-      e.preventDefault();
-      window.scrollTo(0,0);
-    });
+    // Removed to keep consistent with other Back to top links which don't rely on JS
+    // changed to anchor of the #top element
+    //$scrollBtn.on('click', function(e) {
+    //  e.preventDefault();
+    //  window.scrollTo(0,0);
+    //});
   });
 };
 

--- a/Web/Edubase.Web.UI/Views/GOVUK/Layouts/template.cshtml
+++ b/Web/Edubase.Web.UI/Views/GOVUK/Layouts/template.cshtml
@@ -66,7 +66,7 @@
     @RenderSection("Head", required: false)
 
 </head>
-<body class="govuk-template__body @(ViewBag.bodyClasses) no-js">
+<body class="govuk-template__body @(ViewBag.bodyClasses) no-js" id="top">
 <!-- Google Tag Manager (noscript) -->
 @if (acceptsAnalytics == "True")
 {


### PR DESCRIPTION
tweaked both the helper and the accordion so that all "back to top" links go to a "top" anchor on the body element (taking the user to the true top of the page as per the example on GDS)