### PR TITLE
49440 back links

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
@@ -210,8 +210,6 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
             viewModel.CreateEstablishmentPermission = await _securityService.GetCreateEstablishmentPermissionAsync(User);
             viewModel.Type2PhaseMap = _establishmentReadService.GetEstabType2EducationPhaseMap().AsInts();
 
-
-
             var step1OK = viewModel.LocalAuthorityId != null && viewModel.Name != null && viewModel.EstablishmentTypeId != null;
             var step2OK = viewModel.EducationPhaseId != null && viewModel.GenerateEstabNumber != null;
 
@@ -314,6 +312,30 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
                 }
             }
             return View(viewModel);
+        }
+
+        public ActionResult GoBack(CreateChildrensCentreViewModel viewModel)
+        {
+            switch (viewModel.StepName)
+            {
+                case CreateEstablishmentViewModel.eEstabCreateSteps.Step1:
+                    //Shouldn't be needed
+                    return View(viewModel);
+                case CreateEstablishmentViewModel.eEstabCreateSteps.Step2:
+                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step1;
+                    return View(viewModel);
+                case CreateEstablishmentViewModel.eEstabCreateSteps.Step3:
+                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step2;
+                    return View(viewModel);
+                case CreateEstablishmentViewModel.eEstabCreateSteps.Step4:
+                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step2;
+                    return View(viewModel);
+                case CreateEstablishmentViewModel.eEstabCreateSteps.Step5:
+                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step1;
+                    return View(viewModel);
+                default:
+                    return View(viewModel);
+            }
         }
 
         [HttpGet, Route("Details/{id:int}", Name = "EstabDetails")]

--- a/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
@@ -37,6 +37,7 @@ using Edubase.Web.UI.Validation;
 using FluentValidation.Mvc;
 using MoreLinq;
 using ET = Edubase.Services.Enums.eLookupEstablishmentType;
+using CreateSteps = Edubase.Web.UI.Areas.Establishments.Models.CreateEstablishmentViewModel.eEstabCreateSteps;
 using ViewModel = Edubase.Web.UI.Models.EditEstablishmentModel;
 
 namespace Edubase.Web.UI.Areas.Establishments.Controllers
@@ -205,7 +206,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
         }
 
         [HttpPost, ValidateAntiForgeryToken, EdubaseAuthorize, Route("Create")]
-        public async Task<ActionResult> Create(CreateChildrensCentreViewModel viewModel, bool JsDisabled = false, bool routeComplete = false, bool isBack = false)
+        public async Task<ActionResult> Create(CreateChildrensCentreViewModel viewModel, bool JsDisabled = false, bool routeComplete = false)
         {
             viewModel.CreateEstablishmentPermission = await _securityService.GetCreateEstablishmentPermissionAsync(User);
             viewModel.Type2PhaseMap = _establishmentReadService.GetEstabType2EducationPhaseMap().AsInts();
@@ -218,10 +219,15 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
                 viewModel.EducationPhases = (await _cachedLookupService.EducationPhasesGetAllAsync()).Where(x => phaseMap.Contains(x.Id)).ToSelectList(viewModel.EducationPhaseId);
             }
 
-            if (isBack)
+            ModelState.Remove(nameof(viewModel.PreviousStep));
+            ModelState.Remove(nameof(viewModel.CurrentStep));
+            ModelState.Remove(nameof(viewModel.ActionStep));
+
+            if (viewModel.ActionStep < viewModel.CurrentStep)
             {
-                viewModel.StepName = viewModel.PreviousStepName;
-                //need to escape here to redraw the screen and collect additional data
+                viewModel.ActionStep = viewModel.CurrentStep == CreateSteps.ChildrensCentreEntry ? CreateSteps.PhaseOfEducation : viewModel.CurrentStep;
+                viewModel.CurrentStep = viewModel.PreviousStep;
+                viewModel.PreviousStep = viewModel.PreviousStep - 1;
                 return View(viewModel);
             }
 
@@ -230,51 +236,48 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
 
             if (viewModel.EstablishmentTypeId == 41 && routeComplete && step1OK)
             {
-                viewModel.PreviousStepName = viewModel.StepName;
-                viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step5;
-                var result = await new CreateChildrensCentreViewModelValidator(_establishmentReadService).ValidateAsync(viewModel);
-                result.AddToModelState(ModelState, string.Empty);
-
                 return ModelState.IsValid ? await CreateChildrensCentre(viewModel) : View(viewModel);
             }
 
-            if (viewModel.EstablishmentTypeId == 41 && viewModel.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step1 && !routeComplete && step1OK)
+            if (ModelState.IsValid)
             {
-                viewModel.PreviousStepName = viewModel.StepName;
-                viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step5;
+                viewModel.PreviousStep = viewModel.CurrentStep;
+                viewModel.CurrentStep = viewModel.ActionStep;
+            }
+
+            if (viewModel.EstablishmentTypeId == 41 && viewModel.ActionStep == CreateSteps.PhaseOfEducation && !routeComplete && step1OK)
+            {
+                viewModel.CurrentStep = CreateSteps.ChildrensCentreEntry;
+                viewModel.ActionStep = CreateSteps.Complete;
                 //need to escape here to redraw the screen and collect additional data
                 return View(viewModel);
             }
 
-            if (viewModel.StepName != CreateEstablishmentViewModel.eEstabCreateSteps.Step3 && !routeComplete)
+            if (viewModel.ActionStep != CreateSteps.EstabNumberGenerated && !routeComplete)
             {
                 // we can actively ignore step3, as there is no re-render to the screen we just need to ensure the model is correct as per usual.
-                ModelState.Remove(nameof(viewModel.StepName));
 
-                if (viewModel.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 && step2OK)
+                if (viewModel.ActionStep == CreateSteps.EnterEstabNumber && step2OK)
                 {
                     switch (viewModel.GenerateEstabNumber)
                     {
                         case true:
-                            viewModel.PreviousStepName = viewModel.StepName;
-                            viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step3;
+                            viewModel.ActionStep = CreateSteps.EstabNumberGenerated;
                             // if they opted to generate a number, we dont need to re-render the screen, we can just continue to process below
                             break;
                         case false:
-                            viewModel.PreviousStepName = viewModel.StepName;
-                            viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step4;
+                            viewModel.ActionStep = CreateSteps.ChildrensCentreEntry;
                             return View(viewModel);
                         default:
                             break;
                     };
                 }
 
-                if (viewModel.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step1 && step1OK)
+                if (viewModel.ActionStep == CreateSteps.PhaseOfEducation && step1OK)
                 {
-                    viewModel.PreviousStepName = viewModel.StepName;
-                    viewModel.StepName = viewModel.EstablishmentTypeId != 41
-                        ? CreateEstablishmentViewModel.eEstabCreateSteps.Step2
-                        : CreateEstablishmentViewModel.eEstabCreateSteps.Step5;
+                    viewModel.ActionStep = viewModel.EstablishmentTypeId != 41
+                        ? CreateSteps.EnterEstabNumber
+                        : CreateSteps.Complete;
                 }
             }
 
@@ -324,30 +327,6 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
                 }
             }
             return View(viewModel);
-        }
-
-        public ActionResult GoBack(CreateChildrensCentreViewModel viewModel)
-        {
-            switch (viewModel.StepName)
-            {
-                case CreateEstablishmentViewModel.eEstabCreateSteps.Step1:
-                    //Shouldn't be needed
-                    return View(viewModel);
-                case CreateEstablishmentViewModel.eEstabCreateSteps.Step2:
-                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step1;
-                    return View(viewModel);
-                case CreateEstablishmentViewModel.eEstabCreateSteps.Step3:
-                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step2;
-                    return View(viewModel);
-                case CreateEstablishmentViewModel.eEstabCreateSteps.Step4:
-                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step2;
-                    return View(viewModel);
-                case CreateEstablishmentViewModel.eEstabCreateSteps.Step5:
-                    viewModel.StepName = CreateEstablishmentViewModel.eEstabCreateSteps.Step1;
-                    return View(viewModel);
-                default:
-                    return View(viewModel);
-            }
         }
 
         [HttpGet, Route("Details/{id:int}", Name = "EstabDetails")]

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/CreateEstablishmentViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/CreateEstablishmentViewModel.cs
@@ -45,17 +45,19 @@ namespace Edubase.Web.UI.Areas.Establishments.Models
 
         public bool jsDisabled { get; set; } = false;
 
-        public eEstabCreateSteps StepName { get; set; } = eEstabCreateSteps.Step1;
-
-        public eEstabCreateSteps PreviousStepName { get; set; } = eEstabCreateSteps.Step1;
-
+        public eEstabCreateSteps ActionStep { get; set; } = eEstabCreateSteps.PhaseOfEducation;
+        public eEstabCreateSteps CurrentStep { get; set; } = eEstabCreateSteps.NameEntry;
+        public eEstabCreateSteps PreviousStep { get; set; } = eEstabCreateSteps.Undefined;
+        
         public enum eEstabCreateSteps
         {
-            Step1,
-            Step2,
-            Step3,
-            Step4,
-            Step5
+            Undefined,
+            NameEntry,
+            PhaseOfEducation,
+            EnterEstabNumber,
+            EstabNumberGenerated,
+            ChildrensCentreEntry,
+            Complete
         }
 
     }

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/CreateEstablishmentViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/CreateEstablishmentViewModel.cs
@@ -47,6 +47,8 @@ namespace Edubase.Web.UI.Areas.Establishments.Models
 
         public eEstabCreateSteps StepName { get; set; } = eEstabCreateSteps.Step1;
 
+        public eEstabCreateSteps PreviousStepName { get; set; } = eEstabCreateSteps.Step1;
+
         public enum eEstabCreateSteps
         {
             Step1,

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/Validators/CreateEstablishmentViewModelValidator.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/Validators/CreateEstablishmentViewModelValidator.cs
@@ -3,6 +3,7 @@ using Edubase.Services.Establishments;
 using Edubase.Web.UI.Validation;
 using FluentValidation;
 using System.Linq;
+using CreateSteps = Edubase.Web.UI.Areas.Establishments.Models.CreateEstablishmentViewModel.eEstabCreateSteps;
 
 namespace Edubase.Web.UI.Areas.Establishments.Models.Validators
 {
@@ -33,14 +34,14 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Validators
     {
         public CreateChildrensCentreViewModelValidator(IEstablishmentReadService establishmentReadService)
         {
-            When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step1, () =>
+            When(x => x.ActionStep == CreateSteps.PhaseOfEducation, () =>
             {
                 RuleFor(x => x.Name).NotEmpty().WithMessage("Please enter an establishment name");
                 RuleFor(x => x.LocalAuthorityId).NotEmpty().WithMessage("Please select a local authority");
                 RuleFor(x => x.EstablishmentTypeId).NotEmpty().WithMessage("Please select an establishment type");
             });
 
-            When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2, () =>      //Had some aggro with combining tests, may not work
+            When(x => x.ActionStep == CreateSteps.EnterEstabNumber, () =>      //Had some aggro with combining tests, may not work
             {
                 RuleFor(x => x.EducationPhaseId)
                 .Cascade(CascadeMode.StopOnFirstFailure)
@@ -48,27 +49,27 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Validators
                     .NotEmpty().WithMessage("Please select a phase of education")
                     .Must((m, x) => establishmentReadService.GetEstabType2EducationPhaseMap().AsInts()[m.EstablishmentTypeId.Value].Contains(x.Value))    //Fails here
                     .WithMessage("Education phase is not valid for the selected type of establishment")
-                    .When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 && x.EstablishmentTypeId != 41);
+                    .When(x => x.ActionStep == CreateSteps.EnterEstabNumber && x.EstablishmentTypeId != 41);
                 RuleFor(x => x.GenerateEstabNumber)
                     .NotNull()
                     .WithMessage("Please select 'Generate number' or 'Enter number'")
-                    .When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 && x.EstablishmentTypeId != 41);
+                    .When(x => x.ActionStep == CreateSteps.EnterEstabNumber && x.EstablishmentTypeId != 41);
 
             });
 
-            When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step3, () =>
+            When(x => x.ActionStep == CreateSteps.EstabNumberGenerated, () =>
             {
                 //Don't think we need anything here, as this should be the auto-generation step
             });
 
-            When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step4, () =>
+            When(x => x.ActionStep == CreateSteps.ChildrensCentreEntry, () =>
             {
                 RuleFor(x => x.EstablishmentNumber)
                     .NotEmpty().WithMessage("Please enter an establishment number")
                     .When(x => x.GenerateEstabNumber.HasValue && !x.GenerateEstabNumber.GetValueOrDefault());
             });
 
-            When(x => x.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5, () =>
+            When(x => x.ActionStep == CreateSteps.Complete, () =>
             {
 
                 RuleFor(x => x.OpenDate)

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
@@ -1,4 +1,6 @@
 @using Edubase.Services.Domain
+@using CreateSteps = Edubase.Web.UI.Areas.Establishments.Models.CreateEstablishmentViewModel.eEstabCreateSteps;
+
 @model CreateChildrensCentreViewModel
 @{
     ViewBag.Title = string.Concat(!ViewData.ModelState.IsValid ? "Error: " : string.Empty, "Create a new establishment");
@@ -16,23 +18,6 @@
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Tools", "Index", "Tools", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                 </ol>
-                
-                @*@if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
-                {
-                    // Back button should redirect to step 1
-                    <button type="submit" class="govuk-back-link gias-back-link--button" name="@nameof(Model.StepName)"
-                            value="@Model.GoBack(Model)">
-                        Back
-                    </button>
-                }
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step3 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step4)
-                {
-                    // Back button should redirect to step 2
-                    <button type="submit" class="govuk-back-link gias-back-link--button" name="@nameof(Model.StepName)"
-                            value="@Model.GoBack(Model)">
-                        Back
-                    </button>
-                }*@
             </div>
         </div>
     </div>
@@ -41,10 +26,18 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <button type="submit" class="govuk-back-link gias-back-link--button cancel" name="isBack"
-                    value="true">
-                Back
-            </button>
+
+            @if (Model.CurrentStep == CreateSteps.NameEntry)
+            {
+                @Html.ActionLink("Back", "Index", "Tools", new { area = "" }, new { @class = "govuk-back-link gias-back-link--button cancel", data_module = "govuk-button" })
+            }
+            else
+            {
+                <button type="submit" class="govuk-back-link gias-back-link--button cancel" name="@(nameof(Model.ActionStep))" value="@(Model.PreviousStep)">
+                    Back
+                </button>
+            }
+
         </div>
     </div>
 }
@@ -65,7 +58,8 @@
         {
             @Html.AntiForgeryToken()
             @Html.HiddenFor(x => x.ProcessedWarnings)
-            @Html.HiddenFor(x => x.StepName)
+            @Html.HiddenFor(x => x.PreviousStep)
+            @Html.HiddenFor(x => x.CurrentStep)
             @Html.HiddenFor(x => x.jsDisabled, true)
 
             //Disabled - fix for mobile devices.
@@ -80,7 +74,7 @@
 
             <div class="govuk-grid-column-one-half">
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step1)
+                @if (Model.CurrentStep == CreateSteps.NameEntry)
                 {
                     <p>Set up a new establishment record by completing the fields below and selecting continue.</p>
                     <h2 class="govuk-heading-m">New establishment details</h2>
@@ -103,10 +97,6 @@
                         @Html.ValidationMessageFor(x => x.EstablishmentTypeId, null, new { @class = "govuk-error-message" })
                         @Html.DropDownListFor(x => x.EstablishmentTypeId, Model.EstablishmentTypes, "Please select", new { @class = "govuk-select" })
                     </div>
-
-                    <div class="button-row">
-                        <button type="submit" name="action" value="" class="govuk-button" id="create-submit">Continue</button>
-                    </div>
                 }
                 else
                 {
@@ -116,7 +106,7 @@
                 }
 
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2)
+                @if (Model.CurrentStep == CreateSteps.PhaseOfEducation)
                 {
                     <p>Set up a new establishment record by completing the fields below and selecting continue.</p>
                     <h2 class="govuk-heading-m">New establishment details</h2>
@@ -144,19 +134,18 @@
                             </div>
                         </fieldset>
                     </div>
-
-                    <div class="button-row">
-                        <button type="submit" name="action" value="" class="govuk-button" id="create-submit">Continue</button>
-                    </div>
                 }
                 else
                 {
-                    @Html.HiddenFor(x => x.EducationPhaseId)
-                    @Html.HiddenFor(x => x.GenerateEstabNumber)
+                    if (Model.CurrentStep != CreateSteps.NameEntry)
+                    {
+                        @Html.HiddenFor(x => x.EducationPhaseId)
+                        @Html.HiddenFor(x => x.GenerateEstabNumber)
+                    }
                 }
 
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step3)
+                @if (Model.CurrentStep == CreateSteps.EstabNumberGenerated)
                 {
                     <p>Set up a new establishment record by completing the fields below and selecting create establishment.</p>
                     <h2 class="govuk-heading-m">New establishment details</h2>
@@ -165,7 +154,7 @@
                 }
 
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step4)
+                @if (Model.CurrentStep == CreateSteps.EnterEstabNumber)
                 {
                     <p>Set up a new establishment record by completing the fields below and selecting create establishment.</p>
                     <h2 class="govuk-heading-m">New establishment details</h2>
@@ -185,10 +174,13 @@
                 }
                 else
                 {
-                    @Html.HiddenFor(x => x.EstablishmentNumber)
+                    if (Model.CurrentStep != CreateSteps.NameEntry)
+                    {
+                        @Html.HiddenFor(x => x.EstablishmentNumber)
+                    }
                 }
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
+                @if (Model.CurrentStep == CreateSteps.ChildrensCentreEntry)
                 {
                     <p>Set up a new establishment record by completing the fields below and selecting create establishment.</p>
                     <h2 class="govuk-heading-m">New establishment details</h2>
@@ -276,41 +268,55 @@
                 }
                 else
                 {
-                    @Html.HiddenFor(x => x.OpenDate)
-                    @Html.HiddenFor(x => x.OpenDate.Day)
-                    @Html.HiddenFor(x => x.OpenDate.Month)
-                    @Html.HiddenFor(x => x.OpenDate.Year)
-                    @Html.HiddenFor(x => x.Address.CityOrTown)
-                    @Html.HiddenFor(x => x.Address.Country)
-                    @Html.HiddenFor(x => x.Address.County)
-                    @Html.HiddenFor(x => x.Address.Line1)
-                    @Html.HiddenFor(x => x.Address.Line2)
-                    @Html.HiddenFor(x => x.Address.Line3)
-                    @Html.HiddenFor(x => x.Address.PostCode)
-                    @Html.HiddenFor(x => x.ManagerFirstName)
-                    @Html.HiddenFor(x => x.ManagerLastName)
-                    @Html.HiddenFor(x => x.CentreEmail)
-                    @Html.HiddenFor(x => x.Telephone)
-                    @Html.HiddenFor(x => x.OperationalHoursId)
-                    @Html.HiddenFor(x => x.NumberOfUnderFives)
-                    @Html.HiddenFor(x => x.GovernanceId)
-                    @Html.HiddenFor(x => x.GovernanceDetail)
-                    @Html.HiddenFor(x => x.PhaseId)
-                    @Html.HiddenFor(x => x.DisadvantagedAreaId)
-                    @Html.HiddenFor(x => x.DirectProvisionOfEarlyYears)
-                    @Html.HiddenFor(x => x.EstablishmentStatusId)
+                    if (Model.CurrentStep != CreateSteps.NameEntry)
+                    {
+                        @Html.HiddenFor(x => x.OpenDate)
+                        @Html.HiddenFor(x => x.OpenDate.Day)
+                        @Html.HiddenFor(x => x.OpenDate.Month)
+                        @Html.HiddenFor(x => x.OpenDate.Year)
+                        @Html.HiddenFor(x => x.Address.CityOrTown)
+                        @Html.HiddenFor(x => x.Address.Country)
+                        @Html.HiddenFor(x => x.Address.County)
+                        @Html.HiddenFor(x => x.Address.Line1)
+                        @Html.HiddenFor(x => x.Address.Line2)
+                        @Html.HiddenFor(x => x.Address.Line3)
+                        @Html.HiddenFor(x => x.Address.PostCode)
+                        @Html.HiddenFor(x => x.ManagerFirstName)
+                        @Html.HiddenFor(x => x.ManagerLastName)
+                        @Html.HiddenFor(x => x.CentreEmail)
+                        @Html.HiddenFor(x => x.Telephone)
+                        @Html.HiddenFor(x => x.OperationalHoursId)
+                        @Html.HiddenFor(x => x.NumberOfUnderFives)
+                        @Html.HiddenFor(x => x.GovernanceId)
+                        @Html.HiddenFor(x => x.GovernanceDetail)
+                        @Html.HiddenFor(x => x.PhaseId)
+                        @Html.HiddenFor(x => x.DisadvantagedAreaId)
+                        @Html.HiddenFor(x => x.DirectProvisionOfEarlyYears)
+                        @Html.HiddenFor(x => x.EstablishmentStatusId)
+                    }
+                    else
+                    {
+                        @Html.Hidden(nameof(Model.Address) + "." + nameof(Model.Address.PostCode), "")
+                    }
                 }
 
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step3 ||
-                    Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step4 ||
-                    Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
+
+                @if (Model.CurrentStep == CreateSteps.EstabNumberGenerated ||
+                    Model.CurrentStep == CreateSteps.EnterEstabNumber ||
+                    Model.CurrentStep == CreateSteps.ChildrensCentreEntry)
                 //Not sure whether to segregate this into an additional step or add the create control to the three journey ends
                 //Might be better to do this bit if StepName is (3,4,5).
                 {
                     @Html.Hidden("routeComplete", true)
                     <div class="button-row">
-                        <button type="submit" name="action" value="" class="govuk-button" id="create-submit">Create establishment</button>
+                        <button type="submit" name="@nameof(Model.ActionStep)" value="@Model.ActionStep" class="govuk-button" id="create-submit">Create establishment</button>
                         @Html.ActionLink("Cancel", "Index", "Tools", new { area = "" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
+                    </div>
+                }
+                else
+                {
+                    <div class="button-row">
+                        <button type="submit" name="@nameof(Model.ActionStep)" value="@Model.ActionStep" class="govuk-button" id="create-submit">Continue</button>
                     </div>
                 }
             </div>
@@ -326,7 +332,7 @@
                         <p tabindex="0" id="model-desc">The record you are creating for <strong>@(warning.MessageParameters[0])</strong> in <strong>@(warning.MessageParameters[1])</strong> may duplicate existing record(s): <strong>@(warning.MessageParameters[2])</strong>
                     </div>
                     <div class="button-row">
-                        <button type="submit" name="action" value="" class="govuk-button">Proceed</button>
+                        <button type="submit" name="@nameof(Model.ActionStep)" value="@Model.ActionStep" class="govuk-button">Proceed</button>
                         @Html.ActionLink("Cancel", "Create", "Establishment", new { area = "Establishments" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
                     </div>
                 </div>

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
@@ -16,7 +16,8 @@
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Tools", "Index", "Tools", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                 </ol>
-                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
+                
+                @*@if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
                 {
                     // Back button should redirect to step 1
                     <button type="submit" class="govuk-back-link gias-back-link--button" name="@nameof(Model.StepName)"
@@ -31,8 +32,19 @@
                             value="@Model.GoBack(Model)">
                         Back
                     </button>
-                }
+                }*@
             </div>
+        </div>
+    </div>
+}
+@helper BackLink()
+{
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <button type="submit" class="govuk-back-link gias-back-link--button cancel" name="isBack"
+                    value="true">
+                Back
+            </button>
         </div>
     </div>
 }
@@ -47,22 +59,24 @@
 
 
 @*this is now the journey for JS and non-js users *@
-    <div id="create-establishment">
-        <div class="govuk-grid-row">
-            @using (Html.BeginForm())
-            {
-                @Html.AntiForgeryToken()
-                @Html.HiddenFor(x => x.ProcessedWarnings)
-                @Html.HiddenFor(x => x.StepName)
-                @Html.HiddenFor(x => x.jsDisabled, true)
+<div id="create-establishment">
+    <div class="govuk-grid-row">
+        @using (Html.BeginForm())
+        {
+            @Html.AntiForgeryToken()
+            @Html.HiddenFor(x => x.ProcessedWarnings)
+            @Html.HiddenFor(x => x.StepName)
+            @Html.HiddenFor(x => x.jsDisabled, true)
 
-                //Disabled - fix for mobile devices.
-                //                <div class="govuk-grid-column-full gias-hidden__from-tablet">
-                //                    <div class="button-row govuk-!-margin-bottom-4">
-                //                        <button type="submit" name="action" value="" class="govuk-button">Create establishment</button>
-                //                       @Html.ActionLink("Cancel", "Index", "Tools", new { area = "" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
-                //                    </div>
-                //                </div>
+            //Disabled - fix for mobile devices.
+            //                <div class="govuk-grid-column-full gias-hidden__from-tablet">
+            //                    <div class="button-row govuk-!-margin-bottom-4">
+            //                        <button type="submit" name="action" value="" class="govuk-button">Create establishment</button>
+            //                       @Html.ActionLink("Cancel", "Index", "Tools", new { area = "" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
+            //                    </div>
+            //                </div>
+
+            @BackLink()
 
             <div class="govuk-grid-column-one-half">
 
@@ -301,25 +315,25 @@
                 }
             </div>
 
-                if (Model.WarningsToProcess.Any(x => x.Code == ApiWarningCodes.ESTABLISHMENT_WITH_SAME_NAME_LA_FOUND))
-                {
-                    var warning = Model.WarningsToProcess.First(x => x.Code == ApiWarningCodes.ESTABLISHMENT_WITH_SAME_NAME_LA_FOUND);
-                    <div class="modal-overlay" id="warning-modal-overlay-0"></div>
-                    <div class="modal-content" id="warning-modal-content-0" role="dialog" aria-labelledby="modal-label" aria-describedby="modal-desc">
-                        @Html.ActionLink("Cancel", "Create", "Establishment", new { area = "Establishments" }, new { @class = "modal-exit js-allow-exit", data_module = "govuk-button" })
-                        <div class="modal-inner">
-                            <h3 class="govuk-heading-l" tabindex="0" id="modal-label">Duplicate record</h3>
-                            <p tabindex="0" id="model-desc">The record you are creating for <strong>@(warning.MessageParameters[0])</strong> in <strong>@(warning.MessageParameters[1])</strong> may duplicate existing record(s): <strong>@(warning.MessageParameters[2])</strong>
-                        </div>
-                        <div class="button-row">
-                            <button type="submit" name="action" value="" class="govuk-button">Proceed</button>
-                            @Html.ActionLink("Cancel", "Create", "Establishment", new { area = "Establishments" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
-                        </div>
+            if (Model.WarningsToProcess.Any(x => x.Code == ApiWarningCodes.ESTABLISHMENT_WITH_SAME_NAME_LA_FOUND))
+            {
+                var warning = Model.WarningsToProcess.First(x => x.Code == ApiWarningCodes.ESTABLISHMENT_WITH_SAME_NAME_LA_FOUND);
+                <div class="modal-overlay" id="warning-modal-overlay-0"></div>
+                <div class="modal-content" id="warning-modal-content-0" role="dialog" aria-labelledby="modal-label" aria-describedby="modal-desc">
+                    @Html.ActionLink("Cancel", "Create", "Establishment", new { area = "Establishments" }, new { @class = "modal-exit js-allow-exit", data_module = "govuk-button" })
+                    <div class="modal-inner">
+                        <h3 class="govuk-heading-l" tabindex="0" id="modal-label">Duplicate record</h3>
+                        <p tabindex="0" id="model-desc">The record you are creating for <strong>@(warning.MessageParameters[0])</strong> in <strong>@(warning.MessageParameters[1])</strong> may duplicate existing record(s): <strong>@(warning.MessageParameters[2])</strong>
                     </div>
-                }
+                    <div class="button-row">
+                        <button type="submit" name="action" value="" class="govuk-button">Proceed</button>
+                        @Html.ActionLink("Cancel", "Create", "Establishment", new { area = "Establishments" }, new { @class = "govuk-button govuk-button--secondary cancel", data_module = "govuk-button" })
+                    </div>
+                </div>
             }
-        </div>
+        }
     </div>
+</div>
 
 
 @section ViewScripts {

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Create.cshtml
@@ -16,6 +16,22 @@
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Tools", "Index", "Tools", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                 </ol>
+                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step2 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step5)
+                {
+                    // Back button should redirect to step 1
+                    <button type="submit" class="govuk-back-link gias-back-link--button" name="@nameof(Model.StepName)"
+                            value="@Model.GoBack(Model)">
+                        Back
+                    </button>
+                }
+                @if (Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step3 || Model.StepName == CreateEstablishmentViewModel.eEstabCreateSteps.Step4)
+                {
+                    // Back button should redirect to step 2
+                    <button type="submit" class="govuk-back-link gias-back-link--button" name="@nameof(Model.StepName)"
+                            value="@Model.GoBack(Model)">
+                        Back
+                    </button>
+                }
             </div>
         </div>
     </div>
@@ -26,8 +42,6 @@
         <h1 class="govuk-heading-xl" id="title">Create new establishments</h1>
     </div>
 </div>
-
-
 
 @*js - Temporarily removed, will be re-visited in future sprint" *@
 


### PR DESCRIPTION
Updated journey to allow backlinks to take user to previous screens rather than all the way out to the tools page. To ensure this worked as required there are now three components which get updated with each page build to reference the previous step, the active (current) step, and the point in the journey the user should be directed to upon a successful postback.

To ensure that there no obsolete fields remain populated if the user changes their mind mid-journey, there are also some conditional elements around the hidden fields depending on at which stage the user is at.