### PR TITLE
Feature/53526 la name code guidance

### DIFF
--- a/Web/Edubase.Common/Cache/CacheAccessor.cs
+++ b/Web/Edubase.Common/Cache/CacheAccessor.cs
@@ -1,4 +1,4 @@
-﻿namespace Edubase.Common.Cache
+namespace Edubase.Common.Cache
 {
     using MoreLinq;
     using Newtonsoft.Json;

--- a/Web/Edubase.Services.Texuna/Lookup/Constants.cs
+++ b/Web/Edubase.Services.Texuna/Lookup/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace Edubase.Services.Texuna.Lookup
+namespace Edubase.Services.Texuna.Lookup
 {
     public static class Constants
     {

--- a/Web/Edubase.Services/BlobService.cs
+++ b/Web/Edubase.Services/BlobService.cs
@@ -1,4 +1,4 @@
-﻿namespace Edubase.Services
+namespace Edubase.Services
 {
     using Common;
     using Microsoft.WindowsAzure.Storage;

--- a/Web/Edubase.Services/Edubase.Services.csproj
+++ b/Web/Edubase.Services/Edubase.Services.csproj
@@ -173,7 +173,6 @@
     <Compile Include="Enums\eLookupGovernorRole.cs" />
     <Compile Include="Enums\eLookupGroupStatus.cs" />
     <Compile Include="Enums\eLookupGroupType.cs" />
-    <Compile Include="Enums\eLookupDownloadSource.cs" />
     <Compile Include="Enums\EnumHiddenAttribute.cs" />
     <Compile Include="Enums\eProprietorType.cs" />
     <Compile Include="Enums\eLookupSearchSource.cs" />

--- a/Web/Edubase.Services/Edubase.Services.csproj
+++ b/Web/Edubase.Services/Edubase.Services.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Enums\eLookupGovernorRole.cs" />
     <Compile Include="Enums\eLookupGroupStatus.cs" />
     <Compile Include="Enums\eLookupGroupType.cs" />
+    <Compile Include="Enums\eLookupDownloadSource.cs" />
     <Compile Include="Enums\EnumHiddenAttribute.cs" />
     <Compile Include="Enums\eProprietorType.cs" />
     <Compile Include="Enums\eLookupSearchSource.cs" />

--- a/Web/Edubase.Services/Enums/eLookupDownloadSource.cs
+++ b/Web/Edubase.Services/Enums/eLookupDownloadSource.cs
@@ -1,8 +1,0 @@
-namespace Edubase.Services.Enums
-{
-    public enum eLookupDownloadSource
-    {
-        Guidance,
-        Search,
-    }
-}

--- a/Web/Edubase.Services/Enums/eLookupDownloadSource.cs
+++ b/Web/Edubase.Services/Enums/eLookupDownloadSource.cs
@@ -1,0 +1,8 @@
+namespace Edubase.Services.Enums
+{
+    public enum eLookupDownloadSource
+    {
+        Guidance,
+        Search,
+    }
+}

--- a/Web/Edubase.Services/Enums/eLookupSearchSource.cs
+++ b/Web/Edubase.Services/Enums/eLookupSearchSource.cs
@@ -1,4 +1,4 @@
-﻿namespace Edubase.Services.Enums
+namespace Edubase.Services.Enums
 {
     public enum eLookupSearchSource
     {

--- a/Web/Edubase.UnitTest/app.config
+++ b/Web/Edubase.UnitTest/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -96,7 +96,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadGenerationProgressViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Edubase.Services.Domain;
 using Edubase.Web.UI.Models.Search;
 using Edubase.Services.Enums;
@@ -13,7 +13,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Search
         public int? Step { get; private set; }
         public int? TotalSteps => null;
         public string DownloadName => "establishment";
-
+        public string DownloadSource => "search";
         public eFileFormat FileFormat { get; set; }
 
 

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadGenerationProgressViewModel.cs
@@ -13,7 +13,6 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Search
         public int? Step { get; private set; }
         public int? TotalSteps => null;
         public string DownloadName => "establishment";
-        public string DownloadSource => "search";
         public eFileFormat FileFormat { get; set; }
 
 

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadViewModel.cs
@@ -25,7 +25,6 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Search
         public int? Step => null;
         public int? TotalSteps => null;
         public string DownloadName => "establishment";
-        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
         public bool IncludeEmailAddresses { get; set; }
         public bool IncludeIEBTFields { get; set; }

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/EstablishmentSearchDownloadViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Edubase.Services.Domain;
+using Edubase.Services.Domain;
 using Edubase.Services.Enums;
 using Edubase.Services.Establishments.Downloads;
 using Edubase.Web.UI.Helpers.ModelBinding;
@@ -25,6 +25,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Models.Search
         public int? Step => null;
         public int? TotalSteps => null;
         public string DownloadName => "establishment";
+        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
         public bool IncludeEmailAddresses { get; set; }
         public bool IncludeIEBTFields { get; set; }

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadGenerationProgressViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Edubase.Services.Domain;
 using Edubase.Web.UI.Models.Search;
 using Edubase.Services.Enums;
@@ -14,7 +14,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         public int? Step { get; set; }
         public int? TotalSteps { get; set; }
         public string DownloadName => "governor";
-
+        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
 
         public GovernorSearchDownloadGenerationProgressViewModel(ProgressDto progressDto)

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadGenerationProgressViewModel.cs
@@ -14,7 +14,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         public int? Step { get; set; }
         public int? TotalSteps { get; set; }
         public string DownloadName => "governor";
-        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
 
         public GovernorSearchDownloadGenerationProgressViewModel(ProgressDto progressDto)

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Edubase.Services.Domain;
+using Edubase.Services.Domain;
 using Edubase.Services.Enums;
 using Edubase.Web.UI.Models.Search;
 using System;
@@ -12,6 +12,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps { get; set; } = 0;
         public string DownloadName => "governor";
+        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
         public bool? IncludeNonPublicData { get; set; }
 

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchDownloadViewModel.cs
@@ -12,7 +12,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps { get; set; } = 0;
         public string DownloadName => "governor";
-        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
         public bool? IncludeNonPublicData { get; set; }
 

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadGenerationProgressViewModel.cs
@@ -14,7 +14,6 @@ namespace Edubase.Web.UI.Areas.Groups.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps => 3;
         public string DownloadName => "group";
-        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
 
         public GroupSearchDownloadGenerationProgressViewModel(ProgressDto progressDto)

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadGenerationProgressViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadGenerationProgressViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Edubase.Services.Domain;
 using Edubase.Web.UI.Models.Search;
 using Edubase.Services.Enums;
@@ -14,6 +14,7 @@ namespace Edubase.Web.UI.Areas.Groups.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps => 3;
         public string DownloadName => "group";
+        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
 
         public GroupSearchDownloadGenerationProgressViewModel(ProgressDto progressDto)

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadViewModel.cs
@@ -12,7 +12,6 @@ namespace Edubase.Web.UI.Areas.Groups.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps => 3;
         public string DownloadName => "group";
-        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/GroupSearchDownloadViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Edubase.Services.Domain;
+using Edubase.Services.Domain;
 using Edubase.Services.Enums;
 using Edubase.Web.UI.Models.Search;
 using System;
@@ -12,6 +12,7 @@ namespace Edubase.Web.UI.Areas.Groups.Models
         public int? Step { get; set; } = 0;
         public int? TotalSteps => 3;
         public string DownloadName => "group";
+        public string DownloadSource => "search";
         eFileFormat IDownloadGenerationProgressModel.FileFormat => FileFormat.Value;
     }
 }

--- a/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
@@ -18,6 +18,7 @@ using System.Web.Routing;
 using Edubase.Services;
 using Edubase.Services.Downloads.Models;
 using Edubase.Web.UI.Models.Search;
+using Edubase.Web.UI.Models.Guidance;
 
 namespace Edubase.Web.UI.Controllers
 {
@@ -180,6 +181,27 @@ namespace Edubase.Web.UI.Controllers
                 return RedirectToAction(nameof(DownloadGenerated), new { id = JsonConvert.DeserializeObject<ApiResultDto<Guid>>(response).Value });
             }
         }
+
+        //[HttpPost, Route("Download/LaNameCodes", Name = "LaNameCodesDownload")]
+        //public async Task<ActionResult> LaNameCodesDownload(GuidanceLaNameCodeViewModel DownloadType)
+        //{
+        //    var temp = DownloadType;
+
+        //    return null;
+
+        //    //should redirect to selectformat view
+
+        //    //var blob = _blobService.GetBlobReference(container, file);
+        //    //if (await blob.ExistsAsync())
+        //    //{
+        //    //    var stream = await blob.OpenReadAsync();
+        //    //    return new FileStreamResult(stream, blob.Properties.ContentType)
+        //    //    {
+        //    //        FileDownloadName = blob.Name
+        //    //    };
+        //    //}
+        //    //throw new Exception("File not available");
+        //}
 
         [HttpGet, Route("Download/Establishment/{urn}", Name = "EstabDataDownload")]
         public async Task<ActionResult> DownloadEstablishmentData(int urn, string state, DownloadType? downloadType = null, bool start = false)

--- a/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
@@ -182,27 +182,6 @@ namespace Edubase.Web.UI.Controllers
             }
         }
 
-        //[HttpPost, Route("Download/LaNameCodes", Name = "LaNameCodesDownload")]
-        //public async Task<ActionResult> LaNameCodesDownload(GuidanceLaNameCodeViewModel DownloadType)
-        //{
-        //    var temp = DownloadType;
-
-        //    return null;
-
-        //    //should redirect to selectformat view
-
-        //    //var blob = _blobService.GetBlobReference(container, file);
-        //    //if (await blob.ExistsAsync())
-        //    //{
-        //    //    var stream = await blob.OpenReadAsync();
-        //    //    return new FileStreamResult(stream, blob.Properties.ContentType)
-        //    //    {
-        //    //        FileDownloadName = blob.Name
-        //    //    };
-        //    //}
-        //    //throw new Exception("File not available");
-        //}
-
         [HttpGet, Route("Download/Establishment/{urn}", Name = "EstabDataDownload")]
         public async Task<ActionResult> DownloadEstablishmentData(int urn, string state, DownloadType? downloadType = null, bool start = false)
         {

--- a/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
+++ b/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
@@ -1,13 +1,29 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using System.Web.Mvc;
+using CsvHelper;
+using Edubase.Services;
+using Edubase.Web.UI.Models.Guidance;
+using Microsoft.Data.Edm.Csdl;
 
 namespace Edubase.Web.UI.Controllers
 {
     [RoutePrefix("Guidance"), Route("{action=index}")]
     public class GuidanceController : EduBaseController
     {
+        private readonly IBlobService _blobService;
+
+        public GuidanceController(IBlobService blobService)
+        {
+            _blobService = blobService;
+        }
+
         [Route(Name = "Guidance")]
         public ActionResult Index() => View();
-       
+
         public ActionResult General() => View();
 
         public ActionResult EstablishmentBulkUpdate() => View();
@@ -15,5 +31,52 @@ namespace Edubase.Web.UI.Controllers
         public ActionResult ChildrensCentre() => View();
         public ActionResult Federation() => View();
         public ActionResult Governance() => View();
+        // public ActionResult LaNameCodes() => View();
+
+        public async Task<ActionResult> LaNameCodes()
+        {
+            var viewModel = new GuidanceLaNameCodeViewModel();
+
+            //populate viewmodel with data from blob
+            var data = await GetCsvFromContainer("guidance", "EnglishLaNameCodes.csv");
+            using (var streamReader = new StreamReader(data))
+            using (var csvReader = new CsvReader(streamReader, CultureInfo.InvariantCulture))
+            {
+                var records = csvReader.GetRecords<LaNameCodes>().ToList();
+            }
+
+            return View();
+        }
+
+        private async Task<string> GetCsvFromContainer(string container, string file)
+        {
+            var blob = _blobService.GetBlobReference(container, file);
+            if (await blob.ExistsAsync())
+            {
+                return blob.DownloadTextAsync().Result;
+                // return contents;
+                //var stream = await blob.OpenReadAsync();
+                //return new FileStreamResult(stream, blob.Properties.ContentType)
+                //{
+                //    FileDownloadName = blob.Name
+                //};
+            }
+            throw new Exception("File not available");
+        }
+
+        private async Task<ActionResult> GetFileFromContainer(string container, string file)
+        {
+            var blob = _blobService.GetBlobReference(container, file);
+            if (await blob.ExistsAsync())
+            {
+                var stream = await blob.OpenReadAsync();
+                return new FileStreamResult(stream, blob.Properties.ContentType)
+                {
+                    FileDownloadName = blob.Name
+                };
+            }
+            throw new Exception("File not available");
+        }
     }
 }
+

--- a/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
+++ b/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
@@ -46,35 +46,17 @@ namespace Edubase.Web.UI.Controllers
             });
         }
 
-        //[HttpPost, Route("Download/LaNameCodes", Name = "LaNameCodesDownload")]
-        //public async Task<ActionResult> LaNameCodesDownload(string DownloadType)
-        //{
-        //    var temp = DownloadType;
-
-        //    return View("SelectFormat");
-        //}
-
-        //[HttpGet, Route("PrepareDownload")]
-        //public async Task<ActionResult> PrepareDownload(string DownloadType)
-        //{
-        //    var temp = DownloadType;
-
-        //    return null;
-
-        //    //should redirect to selectformat view
-        //}
-
-        [HttpPost, Route("Download/LaNameCodes", Name = "LaNameCodesDownload")]
-        public async Task<ActionResult> LaNameCodesDownload(eFileFormat? fileFormat, string downloadType)
+        [HttpPost, Route("LaNameCodes", Name = "LaNameCodesDownload")]
+        public async Task<ActionResult> LaNameCodesDownload(GuidanceLaNameCodeViewModel viewModel)
         {
-            if (fileFormat is null)
+            if (!viewModel.FileFormat.HasValue)
             {
-                return View("Downloads/SelectFormat");
+                return View("SelectFormat", viewModel);
             }
 
-            var temp = downloadType + fileFormat;
+            var file = viewModel.DownloadType + "." + viewModel.FileFormat.ToString().ToLower();
 
-            var blob = _blobService.GetBlobReference("guidance", downloadType);
+            var blob = _blobService.GetBlobReference("guidance", file);
             if (await blob.ExistsAsync())
             {
                 var stream = await blob.OpenReadAsync();
@@ -84,8 +66,6 @@ namespace Edubase.Web.UI.Controllers
                 };
             }
             throw new Exception("File not available");
-
-          //  return null;
         }
 
             private async Task<List<LaNameCodes>> GetCsvFromContainer(string container, string file)

--- a/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
+++ b/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Mvc;
@@ -19,7 +20,7 @@ namespace Edubase.Web.UI.Controllers
     public class GuidanceController : EduBaseController
     {
         private readonly IBlobService _blobService;
-        private const string GUIDANCE = "guidance";
+        private const string GUIDANCE_CONTAINER = "guidance";
         private const string ENGLISH_LA_NAME_CODES = "EnglishLaNameCodes.csv";
         private const string WELSH_LA_NAME_CODES = "WelshLaNameCodes.csv";
         private const string OTHER_LA_NAME_CODES = "OtherLaNameCodes.csv";
@@ -41,9 +42,9 @@ namespace Edubase.Web.UI.Controllers
         {
             return View(new GuidanceLaNameCodeViewModel()
             {
-                EnglishLas = await GetCsvFromContainer(GUIDANCE, ENGLISH_LA_NAME_CODES),
-                WelshLas = await GetCsvFromContainer(GUIDANCE, WELSH_LA_NAME_CODES),
-                OtherLas = await GetCsvFromContainer(GUIDANCE, OTHER_LA_NAME_CODES),
+                EnglishLas = await GetCsvFromContainer(GUIDANCE_CONTAINER, ENGLISH_LA_NAME_CODES),
+                WelshLas = await GetCsvFromContainer(GUIDANCE_CONTAINER, WELSH_LA_NAME_CODES),
+                OtherLas = await GetCsvFromContainer(GUIDANCE_CONTAINER, OTHER_LA_NAME_CODES),
             });
         }
 
@@ -55,9 +56,9 @@ namespace Edubase.Web.UI.Controllers
                 return View("SelectFormat", viewModel);
             }
 
-            var file = viewModel.DownloadType + "." + viewModel.FileFormat.ToString().ToLower();
+            var file = viewModel.DownloadName + "." + viewModel.FileFormat.ToString().ToLower();
 
-            var blob = _blobService.GetBlobReference(GUIDANCE, file);
+            var blob = _blobService.GetBlobReference(GUIDANCE_CONTAINER, file);
             if (await blob.ExistsAsync())
             {
                 var stream = await blob.OpenReadAsync();
@@ -69,7 +70,7 @@ namespace Edubase.Web.UI.Controllers
             throw new Exception("File not available");
         }
 
-            private async Task<List<LaNameCodes>> GetCsvFromContainer(string container, string file)
+        private async Task<List<LaNameCodes>> GetCsvFromContainer(string container, string file)
         {
             var blob = _blobService.GetBlobReference(container, file);
 

--- a/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
+++ b/Web/Edubase.Web.UI/Controllers/GuidanceController.cs
@@ -19,6 +19,10 @@ namespace Edubase.Web.UI.Controllers
     public class GuidanceController : EduBaseController
     {
         private readonly IBlobService _blobService;
+        private const string GUIDANCE = "guidance";
+        private const string ENGLISH_LA_NAME_CODES = "EnglishLaNameCodes.csv";
+        private const string WELSH_LA_NAME_CODES = "WelshLaNameCodes.csv";
+        private const string OTHER_LA_NAME_CODES = "OtherLaNameCodes.csv";
 
         public GuidanceController(IBlobService blobService)
         {
@@ -27,11 +31,8 @@ namespace Edubase.Web.UI.Controllers
 
         [Route(Name = "Guidance")]
         public ActionResult Index() => View();
-
         public ActionResult General() => View();
-
         public ActionResult EstablishmentBulkUpdate() => View();
-
         public ActionResult ChildrensCentre() => View();
         public ActionResult Federation() => View();
         public ActionResult Governance() => View();
@@ -40,9 +41,9 @@ namespace Edubase.Web.UI.Controllers
         {
             return View(new GuidanceLaNameCodeViewModel()
             {
-                EnglishLas = await GetCsvFromContainer("guidance", "EnglishLaNameCodes.csv"),
-                WelshLas = await GetCsvFromContainer("guidance", "WelshLaNameCodes.csv"),
-                OtherLas = await GetCsvFromContainer("guidance", "OtherLaNameCodes.csv"),
+                EnglishLas = await GetCsvFromContainer(GUIDANCE, ENGLISH_LA_NAME_CODES),
+                WelshLas = await GetCsvFromContainer(GUIDANCE, WELSH_LA_NAME_CODES),
+                OtherLas = await GetCsvFromContainer(GUIDANCE, OTHER_LA_NAME_CODES),
             });
         }
 
@@ -56,7 +57,7 @@ namespace Edubase.Web.UI.Controllers
 
             var file = viewModel.DownloadType + "." + viewModel.FileFormat.ToString().ToLower();
 
-            var blob = _blobService.GetBlobReference("guidance", file);
+            var blob = _blobService.GetBlobReference(GUIDANCE, file);
             if (await blob.ExistsAsync())
             {
                 var stream = await blob.OpenReadAsync();

--- a/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
+++ b/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
@@ -75,6 +75,9 @@
     <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.5.1.0\lib\net462\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="CsvHelper, Version=28.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsvHelper.28.0.1\lib\net47\CsvHelper.dll</HintPath>
+    </Reference>
     <Reference Include="DM.Common, Version=1.0.7181.19781, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DM.Common.1.2.0.2\lib\net461\DM.Common.dll</HintPath>
     </Reference>
@@ -140,6 +143,9 @@
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.HashCode.1.0.0\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
+++ b/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
@@ -376,6 +376,8 @@
     <Compile Include="Helpers\RouteDto.cs" />
     <Compile Include="Models\Faq\FaqGroupsViewModel.cs" />
     <Compile Include="Models\Faq\FaqGroupViewModel.cs" />
+    <Compile Include="Models\Guidance\GuidanceLaNameCodeViewModel.cs" />
+    <Compile Include="Models\Guidance\LaNameCodes.cs" />
     <Compile Include="Models\News\NewsArticleAuditViewModel.cs" />
     <Compile Include="Models\News\NewsArticlesAuditViewModel.cs" />
     <Compile Include="Models\News\NewsArticlesViewModel.cs" />
@@ -878,6 +880,7 @@
     <Content Include="Views\News\AuditArticles.cshtml" />
     <Content Include="Views\News\AuditArticle.cshtml" />
     <None Include="packages.config" />
+    <Content Include="Views\Guidance\LaNameCodes.cshtml" />
     <None Include="Views\Unauthorized\Index.cshtml" />
     <Content Include="Views\Unauthorized\LoginFailed.cshtml" />
   </ItemGroup>

--- a/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
+++ b/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
@@ -240,6 +240,7 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.6.0.0\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>

--- a/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
+++ b/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
@@ -887,6 +887,7 @@
     <Content Include="Views\News\AuditArticle.cshtml" />
     <None Include="packages.config" />
     <Content Include="Views\Guidance\LaNameCodes.cshtml" />
+    <Content Include="Views\Guidance\SelectFormat.cshtml" />
     <None Include="Views\Unauthorized\Index.cshtml" />
     <Content Include="Views\Unauthorized\LoginFailed.cshtml" />
   </ItemGroup>

--- a/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Edubase.Services.Enums;
 
 namespace Edubase.Web.UI.Models.Guidance
 {
     public class GuidanceLaNameCodeViewModel
     {
         public string DownloadType { get; set; }
+        // public string DownloadName { get; set; } = "guidance";
+        public eFileFormat? FileFormat { get; set; }
         public List<LaNameCodes> EnglishLas { get; set; }
         public List<LaNameCodes> WelshLas { get; set; }
         public List<LaNameCodes> OtherLas { get; set; }

--- a/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
@@ -5,8 +5,7 @@ namespace Edubase.Web.UI.Models.Guidance
 {
     public class GuidanceLaNameCodeViewModel
     {
-        public string DownloadType { get; set; }
-        // public string DownloadName { get; set; } = "guidance";
+        public string DownloadName { get; set; }
         public eFileFormat? FileFormat { get; set; }
         public List<LaNameCodes> EnglishLas { get; set; }
         public List<LaNameCodes> WelshLas { get; set; }

--- a/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
+
 namespace Edubase.Web.UI.Models.Guidance
 {
     public class GuidanceLaNameCodeViewModel
     {
         public string DownloadType { get; set; }
-        public LaNameCodes EnglishLas { get; set; }
-        public LaNameCodes WelshLas { get; set; }
-        public LaNameCodes OtherLas { get; set; }
+        public List<LaNameCodes> EnglishLas { get; set; }
+        public List<LaNameCodes> WelshLas { get; set; }
+        public List<LaNameCodes> OtherLas { get; set; }
     }
 }

--- a/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/Guidance/GuidanceLaNameCodeViewModel.cs
@@ -1,0 +1,10 @@
+namespace Edubase.Web.UI.Models.Guidance
+{
+    public class GuidanceLaNameCodeViewModel
+    {
+        public string DownloadType { get; set; }
+        public LaNameCodes EnglishLas { get; set; }
+        public LaNameCodes WelshLas { get; set; }
+        public LaNameCodes OtherLas { get; set; }
+    }
+}

--- a/Web/Edubase.Web.UI/Models/Guidance/LaNameCodes.cs
+++ b/Web/Edubase.Web.UI/Models/Guidance/LaNameCodes.cs
@@ -1,0 +1,9 @@
+namespace Edubase.Web.UI.Models.Guidance
+{
+    public class LaNameCodes
+    {
+        public string LaName { get; set; }
+        public string LaCode { get; set; }
+        public string OnsLaCode { get; set; }
+    }
+}

--- a/Web/Edubase.Web.UI/Models/Search/IDownloadGenerationProgressModel.cs
+++ b/Web/Edubase.Web.UI/Models/Search/IDownloadGenerationProgressModel.cs
@@ -8,7 +8,6 @@ namespace Edubase.Web.UI.Models.Search
         int? Step { get; }
         int? TotalSteps { get; }
         string DownloadName { get; }
-        string DownloadSource { get; }
         eFileFormat FileFormat { get; }
         ProgressDto Progress { get; }
         string SearchQueryString { get; set; }

--- a/Web/Edubase.Web.UI/Models/Search/IDownloadGenerationProgressModel.cs
+++ b/Web/Edubase.Web.UI/Models/Search/IDownloadGenerationProgressModel.cs
@@ -1,4 +1,4 @@
-﻿using Edubase.Services.Domain;
+using Edubase.Services.Domain;
 using Edubase.Services.Enums;
 
 namespace Edubase.Web.UI.Models.Search
@@ -8,6 +8,7 @@ namespace Edubase.Web.UI.Models.Search
         int? Step { get; }
         int? TotalSteps { get; }
         string DownloadName { get; }
+        string DownloadSource { get; }
         eFileFormat FileFormat { get; }
         ProgressDto Progress { get; }
         string SearchQueryString { get; set; }

--- a/Web/Edubase.Web.UI/Views/Guidance/Index.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/Index.cshtml
@@ -45,6 +45,9 @@
             <li>
                 @Html.ActionLink("Governance guidance", "Governance", "Guidance", new { area = "" }, null)
             </li>
+            <li>
+                @Html.ActionLink("Local authority name and associated codes", "LaNameCodes", "Guidance", new { area = "" }, null)
+            </li>
         </ul>
     </div>
 </div>

--- a/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
@@ -83,7 +83,7 @@
                 </tbody>
             </table>
             <p>
-                <button class="govuk-button" name="DownloadType" value="EnglishLaNameCodes">Download</button><br />
+                <button class="govuk-button" name="DownloadName" value="EnglishLaNameCodes">Download</button><br />
             </p>
 
             <table class="govuk-table gias-table">
@@ -107,7 +107,7 @@
                 </tbody>
             </table>
             <p>
-                <button class="govuk-button" name="DownloadType" value="Wales">Download</button><br />
+                <button class="govuk-button" name="DownloadName" value="WalesLaNameCodes">Download</button><br />
             </p>
 
             <table class="govuk-table gias-table">
@@ -131,7 +131,7 @@
                 </tbody>
             </table>
             <p>
-                <button class="govuk-button" name="DownloadType" value="Others">Download</button><br />
+                <button class="govuk-button" name="DownloadName" value="OthersLaNameCodes">Download</button><br />
             </p>
 
         }

--- a/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
@@ -62,11 +62,8 @@
 
         @using (Html.BeginRouteForm("LaNameCodesDownload"))
         {
-            <p>
-                <button class="govuk-button" name="DownloadType" value="England">Download</button><br />
-            </p>
-
             <table class="govuk-table gias-table">
+                <caption class="govuk-table__caption govuk-table__caption--m">English local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">English local authority (LA) name</th>
@@ -75,19 +72,22 @@
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" data-label="English local authority (LA) name">data</td>
-                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
-                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
-                    </tr>
+                    @foreach (var items in Model.EnglishLas)
+                    {
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell" data-label="English local authority (LA) name">@items.LaName</td>
+                            <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">@items.LaCode</td>
+                            <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">@items.OnsLaCode</td>
+                        </tr>
+                    }
                 </tbody>
             </table>
-
             <p>
-                <button class="govuk-button" name="DownloadType" value="England">Download</button><br />
+                <button class="govuk-button" name="DownloadType" value="EnglishLaNameCodes">Download</button><br />
             </p>
 
             <table class="govuk-table gias-table">
+                <caption class="govuk-table__caption govuk-table__caption--m">Welsh local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">Welsh local authority (LA) name</th>
@@ -96,19 +96,22 @@
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" data-label="Welsh local authority (LA) name">data</td>
-                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
-                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
-                    </tr>
+                    @foreach (var items in Model.WelshLas)
+                    {
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell" data-label="Welsh local authority (LA) name">@items.LaName</td>
+                            <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">@items.LaCode</td>
+                            <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">@items.OnsLaCode</td>
+                        </tr>
+                    }
                 </tbody>
             </table>
-
             <p>
-                <button class="govuk-button" name="DownloadType" value="Others">Download</button><br />
+                <button class="govuk-button" name="DownloadType" value="Wales">Download</button><br />
             </p>
 
             <table class="govuk-table gias-table">
+                <caption class="govuk-table__caption govuk-table__caption--m">Other local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">Other local authority (LA) name</th>
@@ -117,16 +120,21 @@
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                    <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" data-label="'Local authority (LA)' name">data</td>
-                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
-                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
-                    </tr>
+                    @foreach (var items in Model.OtherLas)
+                    {
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell" data-label="'Local authority (LA)' name">@items.LaName</td>
+                            <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">@items.LaCode</td>
+                            <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">@items.OnsLaCode</td>
+                        </tr>
+                    }
                 </tbody>
             </table>
+            <p>
+                <button class="govuk-button" name="DownloadType" value="Others">Download</button><br />
+            </p>
 
         }
-
 
         @helpers.BackToTopLink()
     </div>

--- a/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
@@ -63,7 +63,7 @@
         @using (Html.BeginRouteForm("LaNameCodesDownload"))
         {
             <table class="govuk-table gias-table">
-                <caption class="govuk-table__caption govuk-table__caption--m">English local authorities (LAs)</caption>
+                <caption class="govuk-table__caption govuk-table__caption--m">2.1 English local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">English local authority (LA) name</th>
@@ -87,7 +87,7 @@
             </p>
 
             <table class="govuk-table gias-table">
-                <caption class="govuk-table__caption govuk-table__caption--m">Welsh local authorities (LAs)</caption>
+                <caption class="govuk-table__caption govuk-table__caption--m">2.2 Welsh local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">Welsh local authority (LA) name</th>
@@ -111,7 +111,7 @@
             </p>
 
             <table class="govuk-table gias-table">
-                <caption class="govuk-table__caption govuk-table__caption--m">Other local authorities (LAs)</caption>
+                <caption class="govuk-table__caption govuk-table__caption--m">2.3 Other local authorities (LAs)</caption>
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">Other local authority (LA) name</th>

--- a/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
@@ -1,0 +1,133 @@
+@using Edubase.Web.UI.Models.Guidance
+@model GuidanceLaNameCodeViewModel
+@{
+    ViewBag.Title = "Get Information about Schools";
+    ViewBag.imageMQ = "(max-width: 768px)";
+    ViewBag.SiteSection = "help";
+}
+
+@section BreadCrumbs
+{
+    <div class="govuk-govuk-govuk-govuk-grid-row">
+        <div class="govuk-grid-govuk-grid-govuk-grid-column-full">
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("Help", "Help", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("Guidance", "Index", "Guidance", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                </ol>
+            </div>
+        </div>
+    </div>
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-xl">Local authority name and associated codes</h1>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m">1. Introduction</h2>
+        <p>
+            This guidance shows the corresponding information for the local authority name, the three digit associated code which is now issued by
+            the Get Information about Schools (GIAS) team and used to be known as the local education authority (LEA) number and the 9 digit code issued
+            by the Office for National Statistics (ONS).
+        </p>
+        <p>
+            The ONS advised in 2011, when the Government Statistical Service (GSS) coding and naming policy for some statistical geographies was
+            implemented on January 1st, that the new codes should be used in all exchanges of statistics and published outputs that normally include codes.
+            The Department for Education (DfE) had then and continue to have no firm proposals to apply the new codes to school numbering,
+            UPRNs, data collections or data transfers with local authorities.
+        </p>
+        <p>
+            The ONS codes are made up of two parts within the format ANNNNNNNN.
+            The first three characters (ANN) represent the area entity (i.e. an area type, such as county), with the first alpha value representing
+            the country within which the entity lies. The second part of the code comprises six number characters (NNNNNN) representing
+            the specific area instance (for example, Hampshire).
+        </p>
+        <p>
+            Further information regarding the coding and naming policy for statistical geographies can be found on the
+            <a href="https://www.ons.gov.uk/methodology/geography" target="_blank" rel="noreferrer noopener">ONS (opens in new tab)</a> website
+        </p>
+
+        <h2 class="govuk-heading-m">2. Tables</h2>
+
+        @using (Html.BeginRouteForm("LaNameCodesDownload"))
+        {
+            <p>
+                <button class="govuk-button" name="DownloadType" value="England">Download</button><br />
+            </p>
+
+            <table class="govuk-table gias-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">English local authority (LA) name</th>
+                        <th class="govuk-table__header">Get Information about Schools (GIAS) local authority (LA) code</th>
+                        <th class="govuk-table__header">Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell" data-label="English local authority (LA) name">data</td>
+                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
+                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>
+                <button class="govuk-button" name="DownloadType" value="England">Download</button><br />
+            </p>
+
+            <table class="govuk-table gias-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">Welsh local authority (LA) name</th>
+                        <th class="govuk-table__header">Get Information about Schools (GIAS) local authority (LA) code</th>
+                        <th class="govuk-table__header">Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell" data-label="Welsh local authority (LA) name">data</td>
+                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
+                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p>
+                <button class="govuk-button" name="DownloadType" value="Others">Download</button><br />
+            </p>
+
+            <table class="govuk-table gias-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">Other local authority (LA) name</th>
+                        <th class="govuk-table__header">Get Information about Schools (GIAS) local authority (LA) code</th>
+                        <th class="govuk-table__header">Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell" data-label="'Local authority (LA)' name">data</td>
+                        <td class="govuk-table__cell" data-label="Get Information about Schools (GIAS) local authority (LA) code">data</td>
+                        <td class="govuk-table__cell" data-label="Office for National Statistics (ONS) local authority (LA) code (also known as Government Statistical Service (GSS) local authority (LA) code on GIAS)">data</td>
+                    </tr>
+                </tbody>
+            </table>
+
+        }
+
+
+        @helpers.BackToTopLink()
+    </div>
+</div>

--- a/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/LaNameCodes.cshtml
@@ -107,7 +107,7 @@
                 </tbody>
             </table>
             <p>
-                <button class="govuk-button" name="DownloadName" value="WalesLaNameCodes">Download</button><br />
+                <button class="govuk-button" name="DownloadName" value="WelshLaNameCodes">Download</button><br />
             </p>
 
             <table class="govuk-table gias-table">
@@ -131,7 +131,7 @@
                 </tbody>
             </table>
             <p>
-                <button class="govuk-button" name="DownloadName" value="OthersLaNameCodes">Download</button><br />
+                <button class="govuk-button" name="DownloadName" value="OtherLaNameCodes">Download</button><br />
             </p>
 
         }

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -75,15 +75,10 @@
     <div class="govuk-grid-column-full">
 
         <h2 class="govuk-heading-m">Download guidance results</h2>
-        @*@if (Model.TotalSteps.HasValue)
-        {
-            <p>@Model.Step of @Model.TotalSteps</p>
-        }*@
 
         <h2 class="govuk-heading-m">Select the file format of the data you are interested in</h2>
         <p>
             You can download your requested data in either CSV or XLSX format.
-            The file will download as a ZIP file: open the ZIP to access its contents.
         </p>
     </div>
 </div>
@@ -92,7 +87,7 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          @Html.HiddenFor(x => x.DownloadType)
+          @Html.HiddenFor(x => x.DownloadName)
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-visually-hidden">Select your preferred format</legend>

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -108,7 +108,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             @Html.HiddenFieldsFromQueryString()
-            <input class="govuk-button" data-module="govuk-button" type="submit" value="Select and continue">
+            <input class="govuk-button" data-module="govuk-button" type="submit" value="Select and download">
         </div>
     </div>
 }

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -25,7 +25,7 @@
                         @Html.ActionLink("Help", "Help", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
                     </li>
                     <li class="govuk-breadcrumbs__list-item">
-                        @Html.ActionLink("LA name and associated codes ", "LaNameCodes", "Guidance", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                        @Html.ActionLink("Local authority name and associated codes ", "LaNameCodes", "Guidance", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
                     </li>
                 </ol>
             </div>

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -14,55 +14,23 @@
 
 @section BreadCrumbs
 {
-    @*@if (Model.SearchQueryString.IsNullOrWhiteSpace() || Model.SearchSource == null)
-    {
-        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-back-link" })
-    }
-    else
-    {
-        if (Model.SearchSource == eLookupSearchSource.Governors)
-        {
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <div class="govuk-breadcrumbs">
-                        <ol class="govuk-breadcrumbs__list">
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "", SelectedTab = SearchViewModel.Tab.Governors }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href=@($"{Url.Action("Index", "GovernorSearch", new {area = "Governors"})}?{Model.SearchQueryString}")>Search results</a></li>
-                        </ol>
-                    </div>
-                </div>
+    <div class="govuk-govuk-govuk-govuk-grid-row">
+        <div class="govuk-grid-govuk-grid-govuk-grid-column-full">
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("Help", "Help", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        @Html.ActionLink("LA name and associated codes ", "LaNameCodes", "Guidance", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })
+                    </li>
+                </ol>
             </div>
-        }
-        else if (Model.SearchSource == eLookupSearchSource.Establishments)
-        {
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <div class="govuk-breadcrumbs">
-                        <ol class="govuk-breadcrumbs__list">
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "", SelectedTab = SearchViewModel.Tab.Establishments }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href=@($"{Url.Action("Index", "EstablishmentsSearch", new {area = "Establishments"})}?{Model.SearchQueryString}")>Search results</a></li>
-                        </ol>
-                    </div>
-                </div>
-            </div>
-        }
-        else if (Model.SearchSource == eLookupSearchSource.Groups)
-        {
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    <div class="govuk-breadcrumbs">
-                        <ol class="govuk-breadcrumbs__list">
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "", SelectedTab = SearchViewModel.Tab.Groups }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href=@($"{Url.Action("Index", "GroupSearch", new {area = "Groups"})}?{Model.SearchQueryString}")>Search results</a></li>
-                        </ol>
-                    </div>
-                </div>
-            </div>
-        }
-    }*@
+        </div>
+    </div>
 }
 
 
@@ -87,7 +55,7 @@
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-          @Html.HiddenFor(x => x.DownloadName)
+            @Html.HiddenFor(x => x.DownloadName)
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-visually-hidden">Select your preferred format</legend>

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -42,7 +42,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-        <h2 class="govuk-heading-m">Download guidance results</h2>
+        <h2 class="govuk-heading-m">Download local authority names and associated codes</h2>
 
         <h2 class="govuk-heading-m">Select the file format of the data you are interested in</h2>
         <p>

--- a/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/SelectFormat.cshtml
@@ -1,7 +1,7 @@
 @using Edubase.Services.Enums
 @using Microsoft.Ajax.Utilities
 @using Edubase.Web.UI.Helpers
-@model IDownloadGenerationProgressModel
+@model Edubase.Web.UI.Models.Guidance.GuidanceLaNameCodeViewModel
 @{
     ViewBag.bodyClasses = "schools-search-page search-page";
     ViewBag.hideLogo = true;
@@ -14,7 +14,7 @@
 
 @section BreadCrumbs
 {
-    @if (Model.SearchQueryString.IsNullOrWhiteSpace() || Model.SearchSource == null)
+    @*@if (Model.SearchQueryString.IsNullOrWhiteSpace() || Model.SearchSource == null)
     {
         @Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-back-link" })
     }
@@ -62,7 +62,7 @@
                 </div>
             </div>
         }
-    }
+    }*@
 }
 
 
@@ -74,11 +74,11 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-        <h2 class="govuk-heading-m">Download @Model.DownloadName search results</h2>
-        @if (Model.TotalSteps.HasValue)
+        <h2 class="govuk-heading-m">Download guidance results</h2>
+        @*@if (Model.TotalSteps.HasValue)
         {
             <p>@Model.Step of @Model.TotalSteps</p>
-        }
+        }*@
 
         <h2 class="govuk-heading-m">Select the file format of the data you are interested in</h2>
         <p>
@@ -88,11 +88,11 @@
     </div>
 </div>
 
-@using (Html.BeginForm("PrepareDownload", "Search", FormMethod.Get))
+@using (Html.BeginForm("LaNameCodesDownload", "Guidance", FormMethod.Post))
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            @Html.HiddenFor(x => x.SearchQueryString)
+          @Html.HiddenFor(x => x.DownloadType)
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-visually-hidden">Select your preferred format</legend>

--- a/Web/Edubase.Web.UI/Views/Shared/Downloads/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/Downloads/SelectFormat.cshtml
@@ -41,7 +41,7 @@
                     <div class="govuk-breadcrumbs">
                         <ol class="govuk-breadcrumbs__list">
                             <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
-                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new {area = "", SelectedTab = SearchViewModel.Tab.Establishments}, new {@class = "govuk-breadcrumbs__link"})</li>
+                            <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Search", "Index", "Search", new { area = "", SelectedTab = SearchViewModel.Tab.Establishments }, new { @class = "govuk-breadcrumbs__link" })</li>
                             <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href=@($"{Url.Action("Index", "EstablishmentsSearch", new {area = "Establishments"})}?{Model.SearchQueryString}")>Search results</a></li>
                         </ol>
                     </div>
@@ -87,7 +87,9 @@
         </p>
     </div>
 </div>
-@using (Html.BeginForm("PrepareDownload", "Search", FormMethod.Get))
+
+@using (Html.BeginForm(Model.DownloadSource == eLookupDownloadSource.Guidance.ToString() ? "Download" : "PrepareDownload",
+                       Model.DownloadSource == eLookupDownloadSource.Guidance.ToString() ? "Guidance" : "Search", FormMethod.Get))
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/Web/Edubase.Web.UI/Views/Shared/Downloads/SelectFormat.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/Downloads/SelectFormat.cshtml
@@ -65,7 +65,6 @@
     }
 }
 
-
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-l">Download data</h1>

--- a/Web/Edubase.Web.UI/Views/_ViewStart.cshtml
+++ b/Web/Edubase.Web.UI/Views/_ViewStart.cshtml
@@ -1,3 +1,3 @@
-﻿@{
+@{
     Layout = "~/Views/Dfe/Layouts/template.cshtml";
 }

--- a/Web/Edubase.Web.UI/packages.config
+++ b/Web/Edubase.Web.UI/packages.config
@@ -8,6 +8,7 @@
   <package id="AzureTableLogger" version="1.1.3" targetFramework="net48" />
   <package id="BeginCollectionItem" version="1.2.1.0" targetFramework="net48" />
   <package id="Castle.Core" version="5.1.0" targetFramework="net48" />
+  <package id="CsvHelper" version="28.0.1" targetFramework="net48" />
   <package id="DM.Common" version="1.2.0.2" targetFramework="net48" />
   <package id="EntityFramework" version="6.4.4" targetFramework="net48" />
   <package id="FluentValidation" version="8.6.2" targetFramework="net48" />
@@ -38,7 +39,9 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.9" targetFramework="net48" />
   <package id="Microsoft.Azure.KeyVault.Core" version="3.0.5" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.HashCode" version="1.0.0" targetFramework="net48" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net48" />
+  <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Data.Edm" version="5.8.5" targetFramework="net48" />
   <package id="Microsoft.Data.OData" version="5.8.5" targetFramework="net48" />
   <package id="Microsoft.Data.Services.Client" version="5.8.5" targetFramework="net48" />


### PR DESCRIPTION
Includes:

- New page under Help->Guidance for LA names and associated codes
- Middle tier updates to get CSV/XSLX data from Blob storage
- Custom SelectFormat page for downloading CSV/XSLX directly without zip compression


Does not include unit tests as the exisitng blob service uses a deprecrated library. This is to be replaced in a separate Story