### PR TITLE
Use replacement API for Lookups

### DIFF
--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -56,6 +56,7 @@
     <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
+    <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />
     <add key="DataQualityUpdatePeriod" value="7" />
     <add key="ApiTraceSessionRetentionCount" value="25" />
     <add key="OSPlacesApiKey" value="" />


### PR DESCRIPTION
Dependency injection container creates a specific named HttpClient and HttpClientFactory for the lookups service
Gets connection string from config for connecting to the new API (no auth required for Lookups). 
Defaults to use the java API if the new API config setting isn't there.