### PR TITLE
Updated Handling of Glossary Content

### DIFF
--- a/Web/Edubase.Web.UI/Views/Glossary/Index.cshtml
+++ b/Web/Edubase.Web.UI/Views/Glossary/Index.cshtml
@@ -49,7 +49,7 @@
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-2">
                                     <h2 class="govuk-heading-s">@item.Title</h2>
-                                    <div class="gias-user-content">@Html.Raw(item.Content)</div>
+                                    <div class="gias-user-content">@Html.Raw(item.Content.Replace("\n", "<br/>"))</div>
                                 </div>
 
                                 @if (Model.UserCanEdit)

--- a/Web/Edubase.Web.UI/Views/Glossary/Index.cshtml
+++ b/Web/Edubase.Web.UI/Views/Glossary/Index.cshtml
@@ -1,3 +1,4 @@
+
 @model GlossaryViewModel
 @{
     ViewBag.Title = "GIAS: Glossary";
@@ -11,7 +12,7 @@
             <div class="govuk-breadcrumbs">
                 <ol class="govuk-breadcrumbs__list">
                     <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Home", "Index", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
-                    <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Help", "Help", "Home", new { area = "" }, new {@class = "govuk-breadcrumbs__link"})</li>
+                    <li class="govuk-breadcrumbs__list-item">@Html.ActionLink("Help", "Help", "Home", new { area = "" }, new { @class = "govuk-breadcrumbs__link" })</li>
                 </ol>
             </div>
         </div>
@@ -49,7 +50,7 @@
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-2">
                                     <h2 class="govuk-heading-s">@item.Title</h2>
-                                    <div class="gias-user-content">@Html.Raw(item.Content.Replace("\n", "<br/>"))</div>
+                                    <div class="gias-user-content">@Html.Raw(System.Text.RegularExpressions.Regex.Replace(item.Content, @"\r\n|\r|\n", "<br/>"))</div>
                                 </div>
 
                                 @if (Model.UserCanEdit)
@@ -59,8 +60,8 @@
                                     </div>
                                 }
                             </div>
-                            }
-                        </div>
+                        }
+                    </div>
                 </div>
             }
         </div>


### PR DESCRIPTION
Small change to how content is handled in the Glossary accordion sections

### Currently, new lines are not being shown
![image](https://user-images.githubusercontent.com/20383305/207819317-6da99fcf-865e-4229-b7dd-224335c60788.png)


### With update
![image](https://user-images.githubusercontent.com/20383305/207819526-a53e713a-2412-4abe-8665-07fe34de67a0.png)


This correction has already been use in FAQ sections

