### PR TITLE
Remove remaining references to `DM.Common`

### DIFF
--- a/Web/.nuget/NuGet.config
+++ b/Web/.nuget/NuGet.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <solution>
-        <add key="disableSourceControlIntegration" value="true" />
-    </solution>
-	<packageSources>
-		<add key="DM Common" value="https://agilefactory.pkgs.visualstudio.com/_packaging/DM.Common/nuget/v3/index.json" />
-	</packageSources>
-</configuration>


### PR DESCRIPTION
## Context

- `Nuget.config` references a private/authenticated/internal nuget feed named `DM Common`
- Usages of the IP Blacklisting functionality of `DM.Common` was removed within PR #220 / agilefactory 53908
- The only remaining reference to `DM.Common` is to this feed
- Automated build and tests pass without the `.nuget` directory at all, and initial manual tests indicate it runs locally fine

## Changes proposed

- Remove references to the now-unused privated/authenticated/internal nuget feed named `DM Common` from `NuGet.config
- Remove the also-unused `disableSourceControlIntegration` setting (used by [Team Foundation Version Control](https://learn.microsoft.com/en-us/nuget/consume-packages/packages-and-source-control#omitting-packages-with-team-foundation-version-control) which isn't in use for this project)
- ... do the above by removing the (now-empty) `NuGet.config` file entirely, and the (now-empty) containing directory