### PR TITLE
Add omitted governance professional to enumset

### DIFF
--- a/Web/Edubase.Services/Enums/EnumSets.cs
+++ b/Web/Edubase.Services/Enums/EnumSets.cs
@@ -39,6 +39,7 @@ namespace Edubase.Services.Enums
             ET.UniversityTechnicalCollege
         }.Cast<int>();
 
+        // See also database table StaffRole, column isOnePersonRole
         public static IEnumerable<GR> eSingularGovernorRoles { get; } = new[]
         {
             GR.ChairOfGovernors,
@@ -51,11 +52,13 @@ namespace Edubase.Services.Enums
             GR.GovernanceProfessionalToAFederation,
             GR.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool,
             GR.GovernanceProfessionalToAMat,
+            GR.Group_SharedGovernanceProfessional,
             GR.Establishment_SharedGovernanceProfessional
         };
 
         public static IEnumerable<int> SingularGovernorRoles { get; } = eSingularGovernorRoles.Cast<int>();
 
+        // See also database table StaffRole, columns isSharing and isShared
         public static IEnumerable<GR> eSharedGovernorRoles { get; } = new[]
         {
             GR.Group_SharedChairOfLocalGoverningBody,
@@ -68,6 +71,7 @@ namespace Edubase.Services.Enums
 
         public static IEnumerable<int> SharedGovernorRoles { get; } = eSharedGovernorRoles.Cast<int>();
 
+        // See also database table StaffRole
         public static IEnumerable<GR> eGovernanceProfessionalRoles { get; } = new[]
         {
             GR.GovernanceProfessionalToALocalAuthorityMaintainedSchool,

--- a/Web/Edubase.ServicesUnitTests/EnumSetTests.cs
+++ b/Web/Edubase.ServicesUnitTests/EnumSetTests.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Edubase.Services.Enums.UnitTests
+{
+    public class EnumSetTests
+    {
+        public static IEnumerable<object[]> ELookupGovernorRoles = EnumSets
+            .eGovernanceProfessionalRoles
+            .Select(role => new object[] { role });
+
+        [Theory]
+        [MemberData(nameof(ELookupGovernorRoles))]
+        public void AllGovernanceProfessionalRolesAreSingularRoles(eLookupGovernorRole role)
+        {
+            Assert.Contains(role, EnumSets.eSingularGovernorRoles);
+        }
+    }
+}


### PR DESCRIPTION
The collection now matches the database and the listed description.

Proposed changes/edits:
- All six governance professional types listed
- Test cases validate this/prevent future accidental regressions

#140851