### PR TITLE
Restrict creating new if would overlap with current governance professional

### DIFF
--- a/Web/Edubase.Services/Enums/EnumSets.cs
+++ b/Web/Edubase.Services/Enums/EnumSets.cs
@@ -82,6 +82,15 @@ namespace Edubase.Services.Enums
             GR.Establishment_SharedGovernanceProfessional,
         };
 
-        public static IEnumerable<int> GovernanceProfessionalRole = eGovernanceProfessionalRoles.Cast<int>();
+        public static IEnumerable<int> GovernanceProfessionalRoles = eGovernanceProfessionalRoles.Cast<int>();
+
+
+        public static IEnumerable<GR> eChairOfLocalGoverningBodyRoles { get; } = new[]
+        {
+            GR.Group_SharedChairOfLocalGoverningBody,
+            GR.Establishment_SharedChairOfLocalGoverningBody,
+        };
+
+        public static IEnumerable<int> ChairOfLocalGoverningBodyRoles = eChairOfLocalGoverningBodyRoles.Cast<int>();
     }
 }


### PR DESCRIPTION
## Background

- There is pre-existing functionality to prevent creating a new chair of a local governing body where it (or the shared equivalent) already exists

## Proposed changes

- Extend pre-existing functionality/behaviour to also apply validation rules permitting only a single appointment of any type of governance professional


**Creating as draft PR for now as unclear if this is to be implemented within frontend/backend(/both).**