### PR TITLE
Rename GID for remaining governance roles

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -239,7 +239,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                 grid.AddHeaderCell("Name", displayPolicy.FullName, "name", "sortText")
                     .AddHeaderCell("Shared with", role.OneOfThese(GR.LocalGovernor, GR.ChairOfLocalGoverningBody),
                         "shared", "sortText")
-                    .AddHeaderCell("GID", displayPolicy.Id, "gid")
+                    .AddHeaderCell("Governance role identifier (GID)", displayPolicy.Id, "gid")
                     .AddHeaderCell("Appointed by", displayPolicy.AppointingBodyId, "appointed", "sortText")
                     .AddHeaderCell("From", displayPolicy.AppointmentStartDate, "fromDate", "sortDate")
                     .AddHeaderCell(role == GR.Member ? "Date stepped down" : "To", includeEndDate, "toDate", "sortDate")


### PR DESCRIPTION
This makes it spelled out for public and non-public pages, consistent with prior work to spell it out for only governance professionals.

#135249