### PR TITLE
Bug/133033 remove glimpse from release

### DIFF
--- a/Web/Edubase.Web.UI/Web.Release.config
+++ b/Web/Edubase.Web.UI/Web.Release.config
@@ -27,4 +27,9 @@
             </outboundRules>
         </rewrite>
     </system.webServer>
-</configuration>
+  <glimpse defaultRuntimePolicy="Off" endpointBaseUri="~/Glimpse.axd" xdt:Transform="Replace">
+    <!-- 
+          For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
+          or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you. 
+      -->
+  </glimpse></configuration>

--- a/Web/Edubase.Web.UI/Web.Release.config
+++ b/Web/Edubase.Web.UI/Web.Release.config
@@ -32,4 +32,5 @@
           For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
           or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you. 
       -->
-  </glimpse></configuration>
+  </glimpse>
+</configuration>


### PR DESCRIPTION
Agreed to just remove glimpse from release builds for now.

Web.config transforms (where you use e.g. Web.Release.config file to modify the settings in Web.config) only work with deployments, not running locally, hence the debug settings with glimpse 'on' remain in Web.config and the release setting goes into Web.Release.config. This also means I haven't been able to test it until it goes in and gets deployed.