### PR TITLE
updated Tab-wrap and opening tables as unique ids.

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/AcademyOpenings/Index.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/AcademyOpenings/Index.cshtml
@@ -93,7 +93,7 @@
     <div class="govuk-grid-column-full" v-show="!isProcessing">
         <div class="gias-tabs-wrapper">
             <!-- Tabs -->
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="calendar-tab-wrap">
                 <ul class="gias-tabs">
                     <li class="gias-tabs__list-item"><a href="#calendar" class="gias-tabs__tab">Opening calendar</a></li>
                     <li class="gias-tabs__list-item"><a href="#academy-search" class="gias-tabs__tab">Academy search</a></li>
@@ -135,7 +135,7 @@
                     </div>
 
 
-                    <table class="govuk-table gias-table academy-openings sortable-table" id="openings-table">
+                    <table class="govuk-table gias-table academy-openings sortable-table" id="academy-openings-table">
                         <caption class="govuk-visually-hidden">Academy openings</caption>
                         <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
@@ -346,7 +346,7 @@
         <h1 class="govuk-heading-xl">Manage academy openings</h1>
     </div>
     <div class="govuk-grid-column-full">
-        <div class="tab-wrap" id="tab-wrap">
+        <div class="tab-wrap" id="opening-calendar-tab-wrap">
             <ul class="gias-tabs">
                 <li class="gias-tabs__list-item gias-tabs__list-item--selected">
                     <a href="#calendar" class="gias-tabs__tab">Opening calendar</a>
@@ -366,7 +366,7 @@
         <div class="top-pagination">
             @Html.Partial("_GenericPaginationV2", Model)
         </div>
-        <table class="govuk-table gias-table academy-openings sortable-table" id="openings-table">
+        <table class="govuk-table gias-table academy-openings sortable-table" id="gias-academy-openings-table">
             <caption class="govuk-visually-hidden">Academy openings</caption>
             <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/AcademyOpenings/SearchAcademyOpenings.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/AcademyOpenings/SearchAcademyOpenings.cshtml
@@ -5,7 +5,7 @@
         <h1 class="govuk-heading-xl">Manage academy openings</h1>
     </div>
     <div class="govuk-grid-column-full">
-        <div class="tab-wrap" id="tab-wrap">
+        <div class="tab-wrap" id="academy-opening-tab-wrap">
             <ul class="gias-tabs">
                 <li class="gias-tabs__list-item">
                     @Html.ActionLink("Opening calendar",

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Details.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Details.cshtml
@@ -146,7 +146,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="school-tab-wrap">
                 <ul class="gias-tabs">
                     @if (Model.TabDisplayPolicy.Details)
                     {

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/GovernanceChangeHistory.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/GovernanceChangeHistory.cshtml
@@ -70,7 +70,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="governance-change-history-tab-wrap">
                 <ul class="gias-tabs">
                     <li class="gias-tabs__list-item gias-tabs__list-item--selected">
                         <span class="gias-tabs__tab">Governance Change History</span>

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/_EditLayoutPage.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/_EditLayoutPage.cshtml
@@ -43,7 +43,7 @@ else
     <div class="govuk-grid-column-full">
 
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="gias-details-tab-wrap">
                 <ul class="gias-tabs">
                     <li class="gias-tabs__list-item @Html.Conditional(string.Equals(Model.SelectedTab, "details"), "gias-tabs__list-item--selected")">
                         <a href="@Url.Action("EditDetails", "Establishment", new {id = Model.Urn, area = "Establishments"})" id="details-tab-link" class="gias-tabs__tab">Details</a>

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
@@ -128,7 +128,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="details-tab-wrap">
                 <ul class="gias-tabs">
                     <li class="gias-tabs__list-item">
                         <a href="#details" id="details-tab-link" class="gias-tabs__tab ">Details</a>

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/GovernanceChangeHistory.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/GovernanceChangeHistory.cshtml
@@ -68,7 +68,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="governance-changes-tab-wrap">
                 <ul class="gias-tabs">
                     @if (Model.IsUserLoggedOn)
                     {

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/_EditLayoutPage.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/_EditLayoutPage.cshtml
@@ -36,7 +36,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="gias-tabs-wrapper">
-            <div class="tab-wrap" id="tab-wrap">
+            <div class="tab-wrap" id="details-tab-wrap">
                 <ul class="gias-tabs">
                     <li class="gias-tabs__list-item @Html.Conditional(Model.SelectedTabName == "details", "gias-tabs__list-item--selected")">
                         <a href="@Url.Action("EditDetails", "Group", new { id = Model.GroupUId, area = "Groups" })" id="details-tab" class="gias-tabs__tab">Details</a>

--- a/Web/Edubase.Web.UI/Views/Downloads/Index.cshtml
+++ b/Web/Edubase.Web.UI/Views/Downloads/Index.cshtml
@@ -48,7 +48,7 @@
 <div class="gias-tabs-wrapper">
     @if (Model.AreScheduledExtractsAvailable)
     {
-        <div class="tab-wrap" id="tab-wrap">
+        <div class="tab-wrap" id="establishment-tab-wrap">
             <ul class="gias-tabs">
                 <li class="gias-tabs__list-item">
                     <a href="#group-data" class="gias-tabs__tab">


### PR DESCRIPTION
tab-wrap and opening tables had same ids so it fails accessibility. To avoid it, just updated them with unique ids