### PR TITLE
Feature/131319 remove D from fscp abbreviation

### DIFF
--- a/Web/Edubase.Web.UI/Views/Home/Responsibilities.cshtml
+++ b/Web/Edubase.Web.UI/Views/Home/Responsibilities.cshtml
@@ -55,7 +55,7 @@
                     <li data-idx="2.2">
                         Key departmental services, such as
                         <a href="https://services.signin.education.gov.uk/" target="_blank" rel="noreferrer noopener">DfE Sign-in (DSI) (opens in new tab)</a>,
-                        <a href="https://www.gov.uk/school-performance-tables" target="_blank" rel="noreferrer noopener">Find school and college performance data in England (FSCPD) (also known as the School Performance Tables (SPT)) (opens in new tab)</a>,
+                        <a href="https://www.gov.uk/school-performance-tables" target="_blank" rel="noreferrer noopener">Find school and college performance data in England (FSCP) (also known as the School Performance Tables (SPT)) (opens in new tab)</a>,
                         Analyse School Performance (ASP) and
                         <a href="https://schools-financial-benchmarking.service.gov.uk/" target="_blank" rel="noreferrer noopener">School Financial Benchmarking (SFB) (opens in new tab)</a>
                         use the information in GIAS to directly feed their services. If GIAS information is incorrect establishments (where applicable) may not be represented correctly on these key services that are available to the public and/or individual establishments.


### PR DESCRIPTION
Remove D from fscp abbreviation on the Help->Service information and users responsibilities page