### PR TITLE
fix to show changes tab for all establishment types and all users

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/TabDisplayPolicy.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/TabDisplayPolicy.cs
@@ -57,7 +57,6 @@ namespace Edubase.Web.UI.Areas.Establishments.Models
                 policy.UrbanRuralId, policy.GSSLAId, policy.Easting, policy.Northing, policy.MSOAId, policy.LSOAId
             }.Any(x => x == true);
 
-            ChangeHistory = !model.TypeId.OneOfThese(ET.SecureAcademies16to19);
             Links = !model.TypeId.OneOfThese(ET.SecureAcademies16to19);
         }
 

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -53,7 +53,8 @@
     <add key="owin:appStartup" value="SASimulatorConfiguration" />
     <add key="SASimulatorGuid" value="" />
     <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/" />
-    <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
+    <!--<add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />-->
+    <add key="TexunaApiBaseAddress" value="https://localhost:8443/edubase/rest/" />
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
     <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />

--- a/Web/Edubase.Web.UIUnitTests/Areas/Establishments/Models/TabDisplayPolicyTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Establishments/Models/TabDisplayPolicyTests.cs
@@ -39,10 +39,8 @@ namespace Edubase.Web.UIUnitTests.Areas.Establishments.Models
         }
 
         /// <summary>
-        /// Test Changes tab setting depending on Establishment type
+        /// Test Links tab setting depending on Establishment type
         /// </summary>
-        /// <param name="establishmentTypeId"></param>
-        /// <param name="expectedChangesTab"></param>
         [Theory]
         [MemberData(nameof(EstablishmentTypeChangesAndLinksTestData))]
         public void EstablishmentTypeId_SetsExpectedChangesTab(int establishmentTypeId, bool expectedChangesTab, bool expectedLinksTab)
@@ -61,8 +59,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Establishments.Models
         /// <summary>
         /// Test IEBT, Location and HelpDesk tab settings depending on display-policy fields being true
         /// </summary>
-        /// <param name="displayPolicy"></param>
-        /// <param name="expectedTabDisplayPolicy"></param>
         [Theory]
         [MemberData(nameof(DisplayPolicyTestData))]
         public void EstablishmentDisplayEditPolicy_SetsExpectedDependentTabs(EstablishmentDisplayEditPolicy displayPolicy, TabDisplayPolicy expectedTabDisplayPolicy)
@@ -216,7 +212,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Establishments.Models
                 new object[] { ET.OtherIndependentSpecialSchool, true, true},
                 new object[] { ET.PlayingForSuccessCentres, true, true},
                 new object[] { ET.PupilReferralUnit,true, true},
-                new object[] { ET.SecureAcademies16to19, false, false},
+                new object[] { ET.SecureAcademies16to19, true, false},
                 new object[] { ET.SecureUnits, true, true},
                 new object[] { ET.ServiceChildrensEducation, true, true},
                 new object[] { ET.SixthFormCentres, true, true},


### PR DESCRIPTION
An undo of a previous change to remove changes tab from 16-19 establishment view