### PR TITLE
Epic/governance professional  147390  display vs edit policy

### DIFF
--- a/Web/Edubase.Services/Edubase.Services.csproj
+++ b/Web/Edubase.Services/Edubase.Services.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Geo\PlaceDto.cs" />
     <Compile Include="Geo\PlacesLookupService.cs" />
     <Compile Include="Governors\DisplayPolicies\GovernorDisplayPolicy.cs" />
+    <Compile Include="Governors\DisplayPolicies\GovernorEditPolicy.cs" />
     <Compile Include="Governors\Downloads\GovernorSearchDownloadPayload.cs" />
     <Compile Include="Governors\IGovernorsWriteService.cs" />
     <Compile Include="Governors\Models\GovernorAppointment.cs" />

--- a/Web/Edubase.Services/Governors/DisplayPolicies/GovernorEditPolicy.cs
+++ b/Web/Edubase.Services/Governors/DisplayPolicies/GovernorEditPolicy.cs
@@ -1,0 +1,20 @@
+﻿namespace Edubase.Services.Governors.DisplayPolicies
+{
+    public class GovernorEditPolicy
+    {
+        public bool Id { get; set; }
+        public bool FullName { get; set; }
+        public bool AppointmentStartDate { get; set; }
+        public bool AppointmentEndDate { get; set; }
+        public bool RoleId { get; set; } = true;
+        public bool AppointingBodyId { get; set; }
+        public bool EmailAddress { get; set; }
+        public bool DOB { get; set; }
+        public bool PostCode { get; set; }
+        public bool PreviousFullName { get; set; }
+        public bool TelephoneNumber { get; set; }
+
+        public GovernorEditPolicy Clone() => MemberwiseClone() as GovernorEditPolicy;
+
+    }
+}

--- a/Web/Edubase.Services/Governors/IGovernorsReadService.cs
+++ b/Web/Edubase.Services/Governors/IGovernorsReadService.cs
@@ -14,7 +14,8 @@ namespace Edubase.Services.Governors
         Task<ApiPagedResult<SearchGovernorModel>> SearchAsync(GovernorSearchPayload payload, IPrincipal principal);
         Task<GovernorsDetailsDto> GetGovernorListAsync(int? urn = null, int? groupUId = null, IPrincipal principal = null);
         Task<GovernorPermissions> GetGovernorPermissions(int? urn = default(int?), int? groupUId = default(int?), IPrincipal principal = null);
-        Task<GovernorDisplayPolicy> GetEditorDisplayPolicyAsync(eLookupGovernorRole role, bool isGroup, IPrincipal principal);
+        Task<GovernorDisplayPolicy> GetDisplayPolicyAsync(eLookupGovernorRole role, int? urn = default(int?), int? groupUId = default(int?), IPrincipal principal = null);
+        Task<GovernorEditPolicy> GetEditPolicyAsync(eLookupGovernorRole role, bool isGroup, IPrincipal principal);
         Task<GovernorModel> GetGovernorAsync(int gid, IPrincipal principal);
         Task<IEnumerable<GovernorModel>> GetSharedGovernorsAsync(int establishmentUrn, IPrincipal principal);
         Task<string> GetGovernorBulkUpdateTemplateUri(IPrincipal principal);

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -330,6 +330,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             viewModel.GovernorRole = role.Value;
             await PopulateSelectLists(viewModel);
             viewModel.EditPolicy = await _governorsReadService.GetEditPolicyAsync(role.Value, groupUId.HasValue, User);
+            viewModel.DisplayPolicy = await _governorsReadService.GetDisplayPolicyAsync(role.Value, null, groupUId, User);
 
             ModelState.Clear();
 
@@ -472,6 +473,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
         {
             await PopulateSelectLists(viewModel);
             viewModel.EditPolicy = await _governorsReadService.GetEditPolicyAsync(viewModel.GovernorRole, viewModel.GroupUId.HasValue, User);
+            viewModel.DisplayPolicy = await _governorsReadService.GetDisplayPolicyAsync(viewModel.GovernorRole, null, viewModel.GroupUId, User);
 
             var governorModel = new GovernorModel
             {
@@ -638,7 +640,8 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 DateTermEnds = new DateTimeViewModel(governor.AppointmentEndDate),
                 NewLocalGovernor = new GovernorViewModel
                 {
-                    EditPolicy = await _governorsReadService.GetEditPolicyAsync((RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ?? (eLookupGovernorRole) governor.RoleId.Value), false, User)
+                    EditPolicy = await _governorsReadService.GetEditPolicyAsync((RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ?? (eLookupGovernorRole) governor.RoleId.Value), false, User),
+                    DisplayPolicy = await _governorsReadService.GetDisplayPolicyAsync((RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ?? (eLookupGovernorRole) governor.RoleId.Value), establishmentUrn, null, User),
                 },
                 SharedGovernors = (await Task.WhenAll(governors.Select(async g => await SharedGovernorViewModel.MapFromGovernor(g, establishmentUrn, _cachedLookupService)))).ToList(),
                 NewChairType = ReplaceChairViewModel.ChairType.LocalChair,
@@ -774,6 +777,10 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             model.NewLocalGovernor.EditPolicy = await _governorsReadService.GetEditPolicyAsync(
                 (RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ??
                  (eLookupGovernorRole) governor.RoleId.Value), false, User);
+
+            model.NewLocalGovernor.DisplayPolicy = await _governorsReadService.GetDisplayPolicyAsync(
+                (RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ??
+                 (eLookupGovernorRole) governor.RoleId.Value), model.Urn, null, User);
 
             var sourceGovernors = (await Task.WhenAll(governors.Select(async g => await SharedGovernorViewModel.MapFromGovernor(g, model.Urn.Value, _cachedLookupService)))).ToList();
             if (model.SharedGovernors == null)

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -85,7 +85,8 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             var domainModel = await _governorsReadService.GetGovernorListAsync(establishmentUrn, groupUId, User);
             var governorPermissions = await _governorsReadService.GetGovernorPermissions(establishmentUrn, groupUId, User);
 
-            var viewModel = new GovernorsGridViewModel(domainModel,
+            var viewModel = new GovernorsGridViewModel(
+                domainModel,
                 true,
                 groupUId,
                 establishmentUrn,
@@ -328,7 +329,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             viewModel.GovernorRoleName = _nomenclatureService.GetGovernorRoleName(role.Value);
             viewModel.GovernorRole = role.Value;
             await PopulateSelectLists(viewModel);
-            viewModel.DisplayPolicy = await _governorsReadService.GetEditorDisplayPolicyAsync(role.Value, groupUId.HasValue, User);
+            viewModel.EditPolicy = await _governorsReadService.GetEditPolicyAsync(role.Value, groupUId.HasValue, User);
 
             ModelState.Clear();
 
@@ -470,7 +471,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
         public async Task<ActionResult> AddEditOrReplace(CreateEditGovernorViewModel viewModel)
         {
             await PopulateSelectLists(viewModel);
-            viewModel.DisplayPolicy = await _governorsReadService.GetEditorDisplayPolicyAsync(viewModel.GovernorRole, viewModel.GroupUId.HasValue, User);
+            viewModel.EditPolicy = await _governorsReadService.GetEditPolicyAsync(viewModel.GovernorRole, viewModel.GroupUId.HasValue, User);
 
             var governorModel = new GovernorModel
             {
@@ -637,7 +638,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 DateTermEnds = new DateTimeViewModel(governor.AppointmentEndDate),
                 NewLocalGovernor = new GovernorViewModel
                 {
-                    DisplayPolicy = await _governorsReadService.GetEditorDisplayPolicyAsync((RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ?? (eLookupGovernorRole) governor.RoleId.Value), false, User)
+                    EditPolicy = await _governorsReadService.GetEditPolicyAsync((RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ?? (eLookupGovernorRole) governor.RoleId.Value), false, User)
                 },
                 SharedGovernors = (await Task.WhenAll(governors.Select(async g => await SharedGovernorViewModel.MapFromGovernor(g, establishmentUrn, _cachedLookupService)))).ToList(),
                 NewChairType = ReplaceChairViewModel.ChairType.LocalChair,
@@ -770,7 +771,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             var governors = (await _governorsReadService.GetSharedGovernorsAsync(model.Urn.Value, User)).Where(g =>
                 roles.Contains((eLookupGovernorRole) g.RoleId) && g.Id != model.ExistingGovernorId).ToList();
 
-            model.NewLocalGovernor.DisplayPolicy = await _governorsReadService.GetEditorDisplayPolicyAsync(
+            model.NewLocalGovernor.EditPolicy = await _governorsReadService.GetEditPolicyAsync(
                 (RoleEquivalence.GetLocalEquivalentToSharedRole((eLookupGovernorRole) governor.RoleId.Value) ??
                  (eLookupGovernorRole) governor.RoleId.Value), false, User);
 

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorViewModel.cs
@@ -93,7 +93,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         [DisplayName("Previous last name")]
         public string PreviousLastName { get; set; }
 
-        public GovernorDisplayPolicy DisplayPolicy { get; internal set; }
+        public GovernorEditPolicy EditPolicy { get; internal set; }
 
         public IEnumerable<SelectListItem> Titles { get; set; } = new List<SelectListItem>();
         public IEnumerable<SelectListItem> PreviousTitles { get; set; } = new List<SelectListItem>();

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorViewModel.cs
@@ -94,6 +94,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
         public string PreviousLastName { get; set; }
 
         public GovernorEditPolicy EditPolicy { get; internal set; }
+        public GovernorDisplayPolicy DisplayPolicy { get; internal set; }
 
         public IEnumerable<SelectListItem> Titles { get; set; } = new List<SelectListItem>();
         public IEnumerable<SelectListItem> PreviousTitles { get; set; } = new List<SelectListItem>();

--- a/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
@@ -1,5 +1,7 @@
+@using System.Linq.Expressions
 @using Edubase.Common
 @using Edubase.Services.Enums
+@using Edubase.Web.UI.Areas.Governors.Models
 @model Edubase.Web.UI.Areas.Governors.Models.GovernorViewModel
 
 @if (EnumSets.eGovernanceProfessionalRoles.Contains(Model.GovernorRole))
@@ -14,8 +16,8 @@
 }
 else
 {
-    @DisplayName()
     @DisplayGid()
+    @DisplayName()
     @DisplayAppointingBody()
     @DisplayAppointmentDates()
     @DisplayEmail()
@@ -25,102 +27,306 @@ else
     @DisplayTelephoneNumber()
 }
 
-@helper DisplayGid()
+
+@* TODO: Move away from a helper, and to a view model *@
+@* Web/Edubase.Web.UI/Views/Shared/EditorTemplates/DateTimeViewModel.cshtml *@
+@helper GdsStyledFormFieldTextBoxForNumber(
+    Expression<Func<GovernorViewModel, int?>> expression,
+    bool isVisible,
+    bool isEditable,
+    bool isRequired = false,
+    string customInputId = null,
+    string labelText = null,
+    bool displayTooltip = false,
+    string tooltipLinkText = null,
+    string tooltipHeader = null,
+    string tooltipBody = null,
+    string placeholder = null,
+    bool displayFoldOutDetails = false,
+    string hintText = null,
+    string foldOutTitleText = "",
+    string foldOutContentHtml = "")
 {
-    if (Model.EditPolicy.Id)
+    if (isVisible)
     {
-        <div class="govuk-form-group">
-            <label class="govuk-label" for="governorGidInput">
-                Governance role identifier (GID)
-                <a id="GidTooltipLink" href="#help-text-gid" class="help-icon modal-link">
-                    <span class="govuk-visually-hidden">Help with the governance role identifier field</span>
-                    @helpers.DialogHiddenPrompt()
-                </a>
+        var inputId = customInputId ?? @Html.IdFor(expression).ToString();
+        // var inputId = customInputId ?? "";
+        var errorsWrapperId = $"{inputId}-errors";
+        var toolTipLinkId = $"{inputId}-tooltip-link";
+        var hintTextId = $"{inputId}-hint";
+        var helpTextId = $"{inputId}-help-text";
+
+        var isReadOnly = isVisible && !isEditable;
+
+        var additionalInfo = " (required)";
+
+        var validationCssClassForFormGroup = Html.ValidationCssClassFor(expression);
+        var validationCssClassForTextBox = Html.TextBoxValidationClass(expression);
+
+
+        <div class="govuk-form-group @validationCssClassForFormGroup">
+            <label class="govuk-label" for="@inputId">
+                @labelText
+                @if (isRequired)
+                {
+                    @additionalInfo
+                }
+                @if (displayTooltip)
+                {
+                    <a id="@toolTipLinkId" href="#@helpTextId" class="help-icon modal-link">
+                        <span class="govuk-visually-hidden">@tooltipLinkText</span>
+                        @helpers.DialogHiddenPrompt()
+                    </a>
+                }
             </label>
-            <div class="govuk-grid-column-full helptext-container">
-                <div id="help-text-gid">
-                    <h3 class="govuk-heading-s make-modal-header">Governance role identifier (GID)</h3>
-                    <p class="govuk-body">
-                        This field is generated internally by GIAS, and is not editable by users.
-                    </p>
+            @if (displayTooltip)
+            {
+                <div class="govuk-grid-column-full helptext-container">
+                    <div id="@helpTextId">
+                        <h3 class="govuk-heading-s make-modal-header">@tooltipHeader</h3>
+                        <p class="govuk-body">
+                            @Html.Raw(tooltipBody)
+                        </p>
+                    </div>
                 </div>
-            </div>
-            <input id="governorGidInput" class="govuk-input" value="@Model.GID" readonly="readonly" disabled="disabled" placeholder="This value is generated internally by GIAS"/>
+            }
+
+            @if (displayFoldOutDetails)
+            {
+                <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                            @foldOutTitleText
+                        </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        @Html.Raw(foldOutContentHtml)
+                    </div>
+                </details>
+            }
+
+            <span id="@errorsWrapperId">
+                @Html.ValidationMessageFor(expression, null, new {@class = "govuk-error-message"})
+            </span>
+
+            @if (!string.IsNullOrWhiteSpace(hintText))
+            {
+                <p id="@hintTextId" class="govuk-hint">@hintText</p>
+            }
+
+            @{
+
+                var htmlAttributes = new Dictionary<string, object>()
+                {
+                    {"class", string.Concat("govuk-input ", validationCssClassForTextBox)},
+                    {"id", inputId},
+                    {"aria_describedBy", errorsWrapperId},
+                };
+
+                if (!string.IsNullOrWhiteSpace(placeholder))
+                {
+                    htmlAttributes.Add("placeholder", placeholder);
+                }
+                if (isReadOnly)
+                {
+                    htmlAttributes.Add("disabled", "disabled");
+                }
+
+                //
+                // Specific to numeric input:
+                //
+                htmlAttributes.Add("inputmode", "numeric");
+            }
+            @Html.TextBoxFor(expression, htmlAttributes)
         </div>
     }
+}
+
+@* TODO: Move away from a helper, and to a view model *@
+@* Web/Edubase.Web.UI/Views/Shared/EditorTemplates/DateTimeViewModel.cshtml *@
+@helper GdsStyledFormFieldTextBox(
+    Expression<Func<GovernorViewModel, string>> expression,
+    bool isVisible,
+    bool isEditable,
+    bool isRequired = false,
+    string customInputId = null,
+    string labelText = null,
+    bool displayTooltip = false,
+    string tooltipLinkText = null,
+    string tooltipHeader = null,
+    string tooltipBody = null,
+    string placeholder = null,
+    bool displayFoldOutDetails = false,
+    string hintText = null,
+    string foldOutTitleText = "",
+    string foldOutContentHtml = "")
+{
+    if (isVisible)
+    {
+        var inputId = customInputId ?? @Html.IdFor(expression).ToString();
+        // var inputId = customInputId ?? "";
+        var errorsWrapperId = $"{inputId}-errors";
+        var toolTipLinkId = $"{inputId}-tooltip-link";
+        var hintTextId = $"{inputId}-hint";
+        var helpTextId = $"{inputId}-help-text";
+
+        var isReadOnly = isVisible && !isEditable;
+
+        var additionalInfo = " (required)";
+
+        var validationCssClassForFormGroup = Html.ValidationCssClassFor(expression);
+        var validationCssClassForTextBox = Html.TextBoxValidationClass(expression);
+
+
+        <div class="govuk-form-group @validationCssClassForFormGroup">
+            <label class="govuk-label" for="@inputId">
+                @labelText
+                @if (isRequired)
+                {
+                    @additionalInfo
+                }
+                @if (displayTooltip)
+                {
+                    <a id="@toolTipLinkId" href="#@helpTextId" class="help-icon modal-link">
+                        <span class="govuk-visually-hidden">@tooltipLinkText</span>
+                        @helpers.DialogHiddenPrompt()
+                    </a>
+                }
+            </label>
+            @if (displayTooltip)
+            {
+                <div class="govuk-grid-column-full helptext-container">
+                    <div id="@helpTextId">
+                        <h3 class="govuk-heading-s make-modal-header">@tooltipHeader</h3>
+                        <p class="govuk-body">
+                            @Html.Raw(tooltipBody)
+                        </p>
+                    </div>
+                </div>
+            }
+
+            @if (displayFoldOutDetails)
+            {
+                <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                            @foldOutTitleText
+                        </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        @Html.Raw(foldOutContentHtml)
+                    </div>
+                </details>
+            }
+
+            <span id="@errorsWrapperId">
+                @Html.ValidationMessageFor(expression, null, new {@class = "govuk-error-message"})
+            </span>
+
+            @if (!string.IsNullOrWhiteSpace(hintText))
+            {
+                <p id="@hintTextId" class="govuk-hint">@hintText</p>
+            }
+
+            @{
+
+                var htmlAttributes = new Dictionary<string, object>()
+                {
+                    {"class", string.Concat("govuk-input ", validationCssClassForTextBox)},
+                    {"id", inputId},
+                    {"aria_describedBy", errorsWrapperId},
+                };
+
+                if (!string.IsNullOrWhiteSpace(placeholder))
+                {
+                    htmlAttributes.Add("placeholder", placeholder);
+                }
+                if (isReadOnly)
+                {
+                    htmlAttributes.Add("disabled", "disabled");
+                }
+
+            }
+            @Html.TextBoxFor(expression, htmlAttributes)
+        </div>
+    }
+}
+
+@helper DisplayGid()
+{
+    @GdsStyledFormFieldTextBoxForNumber(
+        expression: x => x.GID,
+        isVisible: Model.DisplayPolicy.Id,
+        isEditable: Model.EditPolicy.Id,
+        isRequired: false,
+        customInputId: "governorGidInput",
+        labelText: "Governance role identifier (GID)",
+        displayTooltip: true,
+        tooltipLinkText: "Help with the governance role identifier field",
+        tooltipHeader: "Governance role identifier (GID)",
+        tooltipBody: "This field is generated internally by GIAS, and is not editable by users.",
+        placeholder: "This value is generated internally by GIAS"
+        )
 }
 
 @helper DisplayName()
 {
     if (Model.EditPolicy.FullName)
     {
-        <div class="govuk-form-group" id="governorFullNameDiv" style="display:none">
-            <label class="govuk-label" for="governorFullNameInput">
-                Name
-                <a id="FullNameTooltipLink" href="#help-text-full-name" class="help-icon modal-link">
-                    <span class="govuk-visually-hidden">Help with the name field</span>
-                    @helpers.DialogHiddenPrompt()
-                </a>
-            </label>
-            <div class="govuk-grid-column-full helptext-container">
-                <div id="help-text-full-name">
-                    <h3 class="govuk-heading-s make-modal-header">Name</h3>
-                    <p class="govuk-body">
-                        <span class="govuk-visually-hidden">Help Text:</span>
-                        The full name input is not editable, because it is auto-populated by joining together name parts.
-                    </p>
-                </div>
-            </div>
-            <input id="governorFullNameInput" class="govuk-input" readonly="readonly" disabled="disabled" value="@Model.FullName"/>
-        </div>
-
         <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.GovernorTitleId)">
-            @Html.LabelFor(x => x.GovernorTitleId, new { @class = "govuk-label", @for = "governor-title-dropdown"})
-            @Html.ValidationMessageFor(x => x.GovernorTitleId, null, new { @class = "govuk-error-message" })
-            @Html.DropDownListFor(x => x.GovernorTitleId, Model.Titles, "", new { id = "governor-title-dropdown", @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.GovernorTitleId)), })
+            @Html.LabelFor(x => x.GovernorTitleId, new {@class = "govuk-label", @for = "governor-title-dropdown"})
+            @Html.ValidationMessageFor(x => x.GovernorTitleId, null, new {@class = "govuk-error-message"})
+            @Html.DropDownListFor(x => x.GovernorTitleId, Model.Titles, "", new {id = "governor-title-dropdown", @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.GovernorTitleId)),})
         </div>
 
-        var additionalInfo = "";
-        if (!EnumSets.eGovernanceProfessionalRoles.Contains(Model.GovernorRole))
-        {
-            additionalInfo = " (required to save record)";
-        }
 
-        {
-            var inputId = "governor-first-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.FirstName)">
-                @Html.LabelFor(x => x.FirstName, $"First name{additionalInfo}", new {@class = "govuk-label", @for = inputId,})
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.FirstName, null, new {@class = "govuk-error-message"})
-                </span>
-                @Html.TextBoxFor(x => x.FirstName, new {@class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.FirstName)), id = inputId, aria_describedBy = errorsWrapperId, })
-            </div>
-        }
+        // Note - this element is used dynamically by JavaScript, therefore is hidden (`display:none`) by default
+        // (unless JavaScript is enabled to make it visible)
+        <div class="govuk-form-group" id="governorFullNameDiv" style="display:none">
+            @GdsStyledFormFieldTextBox(
+                expression: x => x.FullName,
+                isVisible: Model.DisplayPolicy.FullName,
+                isEditable: false, // Derived field, therefore never editable
+                isRequired: false,
+                customInputId: "governorFullNameInput",
+                labelText: "Name",
+                displayTooltip: true,
+                tooltipLinkText: "Help with the name field",
+                tooltipHeader: "Name",
+                tooltipBody: "The full name input is not editable, because it is auto-populated by joining together name parts."
+                )
+        </div>
 
-        {
-            var inputId = "governor-middle-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.MiddleName)">
-                @Html.LabelFor(x => x.MiddleName, new {@class = "govuk-label", @for = inputId})
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.MiddleName, null, new {@class = "govuk-error-message"})
-                </span>
-                @Html.TextBoxFor(x => x.MiddleName, new {@class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.MiddleName)), id = inputId, aria_describedBy = errorsWrapperId,})
-            </div>
-        }
+        // Treat Governance Professionals differently to every other type of governance role?
+        var isFirstNameRequired = true; // !EnumSets.eGovernanceProfessionalRoles.Contains(Model.GovernorRole)
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.FirstName,
+            isVisible: Model.DisplayPolicy.FullName,
+            isEditable: Model.EditPolicy.FullName,
+            isRequired: isFirstNameRequired,
+            customInputId: "governor-first-name-textbox",
+            labelText: "First name"
+            )
 
-        {
-            var inputId = "governor-last-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.LastName)">
-                @Html.LabelFor(x => x.LastName, $"Last name{additionalInfo}", new {@class = "govuk-label", @for = inputId})
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.LastName, null, new {@class = "govuk-error-message"})
-                </span>
-                @Html.TextBoxFor(x => x.LastName, new {@class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.LastName)), id = inputId, aria_describedBy = errorsWrapperId,})
-            </div>
-        }
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.MiddleName,
+            isVisible: Model.DisplayPolicy.FullName,
+            isEditable: Model.EditPolicy.FullName,
+            isRequired: false,
+            customInputId: "governor-middle-name-textbox",
+            labelText: "Middle name"
+            )
+
+        // Treat Governance Professionals differently to every other type of governance role?
+        var isLastNameRequired = true; // !EnumSets.eGovernanceProfessionalRoles.Contains(Model.GovernorRole)
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.LastName,
+            isVisible: Model.DisplayPolicy.FullName,
+            isEditable: Model.EditPolicy.FullName,
+            isRequired: isLastNameRequired,
+            customInputId: "governor-last-name-textbox",
+            labelText: "Last name"
+            )
     }
 }
 
@@ -138,112 +344,70 @@ else
 
 @helper DisplayPostcode()
 {
-    if (Model.EditPolicy.PostCode)
-    {
-        var inputId = "governor-postcode-textbox";
-        var errorsWrapperId = $"{inputId}-errors";
-        <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.PostCode)">
-            <label class="govuk-label" for="@inputId">
-                Home postcode
-                <a id="PostcodeTooltipLink" href="#help-text-postcode" class="help-icon modal-link">
-                    <span class="govuk-visually-hidden">Help with the postcode field</span>
-                    @helpers.DialogHiddenPrompt()
-                </a>
-            </label>
-            <span id="@errorsWrapperId">
-                @Html.ValidationMessageFor(x => x.PostCode, null, new {@class = "govuk-error-message"})
-            </span>
-            <div class="govuk-grid-column-full helptext-container">
-                <div id="help-text-postcode">
-                    <h3 class="govuk-heading-s make-modal-header">Home postcode</h3>
-                    <p class="govuk-body">
-                        This information will not be made public and will only be shared within the Department for Education, across government and with organisations where the department are legally required to do so for business-critical work and safeguarding actions.
-                    </p>
-                </div>
-            </div>
-            @Html.TextBoxFor(x => x.PostCode, new {@class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.PostCode)), id = inputId, aria_describedBy = errorsWrapperId, })
-        </div>
-    }
+    @GdsStyledFormFieldTextBox(
+        expression: x => x.PostCode,
+        isVisible: Model.DisplayPolicy.PostCode,
+        isEditable: Model.EditPolicy.PostCode,
+        isRequired: false,
+        customInputId: "governor-postcode-textbox",
+        labelText: "Home postcode",
+        displayTooltip: true,
+        tooltipLinkText: "Help with the postcode field",
+        tooltipHeader: "Home postcode",
+        tooltipBody: "This information will not be made public and will only be shared within the Department for Education, across government and with organisations where the department are legally required to do so for business-critical work and safeguarding actions."
+        )
 }
 
 @helper DisplayTelephoneNumber()
 {
-    if (Model.EditPolicy.TelephoneNumber)
-    {
-        var inputId = "governor-telephone-number-textbox";
-        var errorsWrapperId = $"{inputId}-errors";
-        <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.TelephoneNumber)">
-            <label class="govuk-label" for="@inputId">
-                Telephone number
-                <a id="TelephoneNumberTooltipLink" href="#help-text-telephonenumber" class="help-icon modal-link">
-                    <span class="govuk-visually-hidden">Help with the telephone number field</span>
-                    @helpers.DialogHiddenPrompt()
-                </a>
-            </label>
-            <span id="@errorsWrapperId">
-                @Html.ValidationMessageFor(x => x.TelephoneNumber, null, new { @class = "govuk-error-message" })
-            </span>
-            <div class="govuk-grid-column-full helptext-container">
-                <div id="help-text-telephonenumber">
-                    <h3 class="govuk-heading-s make-modal-header">Telephone number</h3>
-                    <p class="govuk-body">
-                        This information will not be made public and will only be shared within the Department for Education, across government and with organisations where the department are legally required to do so for business-critical work and safeguarding actions.
-                    </p>
-                </div>
-            </div>
-            @Html.TextBoxFor(x => x.TelephoneNumber, new { @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.TelephoneNumber)), id = inputId, aria_describedBy = errorsWrapperId,})
-        </div>
-    }
+    @GdsStyledFormFieldTextBox(
+        expression: x => x.TelephoneNumber,
+        isVisible: Model.DisplayPolicy.TelephoneNumber,
+        isEditable: Model.EditPolicy.TelephoneNumber,
+        isRequired: false,
+        customInputId: "governor-telephone-number-textbox",
+        labelText: "Home postcode",
+        displayTooltip: true,
+        tooltipLinkText: "Help with the telephone number field",
+        tooltipHeader: "Telephone number",
+        tooltipBody: "This information will not be made public and will only be shared within the Department for Education, across government and with organisations where the department are legally required to do so for business-critical work and safeguarding actions."
+        )
 }
 
 @helper DisplayEmail()
 {
-    if (Model.EditPolicy.EmailAddress)
-    {
-        var labelText = "Email address";
-        if (Model.GovernorRole.OneOfThese(
-            eLookupGovernorRole.ChairOfGovernors,
-            eLookupGovernorRole.ChairOfTrustees,
-            eLookupGovernorRole.AccountingOfficer,
-            eLookupGovernorRole.ChiefFinancialOfficer,
-            eLookupGovernorRole.ChairOfLocalGoverningBody
-            ))
-        {
-            labelText += " (required to save record)";
-        }
+    var isEmailRequired = Model.GovernorRole.OneOfThese(
+        eLookupGovernorRole.ChairOfGovernors,
+        eLookupGovernorRole.ChairOfTrustees,
+        eLookupGovernorRole.AccountingOfficer,
+        eLookupGovernorRole.ChiefFinancialOfficer,
+        eLookupGovernorRole.ChairOfLocalGoverningBody
+        );
 
-        var inputId = "governor-email-textbox";
-        var errorsWrapperId = $"{inputId}-errors";
-        <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.EmailAddress)">
-            @Html.LabelFor(x => x.EmailAddress, labelText, new { @class = "govuk-label", @for = inputId })
-            <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-                <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                        How this email address information is used
-                    </span>
-                </summary>
-                <div class="govuk-details__text">
-                    <p>
-                        The governance professional personal establishment email address must be added here.
-                        If the governance professional does not have an establishment email address, then their work/business email address should be entered here.
-                        If this is also their personal email address, it should be made clear to them how the email address will be used.
-                        The email address must be an up-to-date, valid, and actively monitored email address.
-                        This information is not publicly displayed on the website's interface and is classed as personal data, therefore,
-                        it cannot be shared publicly, for example, through a Freedom of Information (FOI) request.
-                        Under the conditions of Article 6(1)(e) of the UK-GDPR this information can be shared with other government departments,
-                        non-departmental public bodies, arm's length bodies and partners for official functions and tasks within the public interest to be performed.
-                    </p>
-                    <p>
-                        This information is very important as it allows the Department for Education to share important information and messages with the governance professional.
-                    </p>
-                </div>
-            </details>
-            <span id="@errorsWrapperId">
-                @Html.ValidationMessageFor(x => x.EmailAddress, null, new { @class = "govuk-error-message" })
-            </span>
-            @Html.TextBoxFor(x => x.EmailAddress, new { @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.EmailAddress)), id = inputId, aria_describedBy = errorsWrapperId, })
-        </div>
-    }
+    @GdsStyledFormFieldTextBox(
+        expression: x => x.EmailAddress,
+        isVisible: Model.DisplayPolicy.EmailAddress,
+        isEditable: Model.EditPolicy.EmailAddress,
+        isRequired: isEmailRequired,
+        customInputId: "governor-email-textbox",
+        labelText: "Email Address",
+        displayTooltip: false,
+        displayFoldOutDetails: true,
+        foldOutTitleText: "How this email address information is used",
+        foldOutContentHtml: @"<p>
+            The governance professional personal establishment email address must be added here.
+            If the governance professional does not have an establishment email address, then their work/business email address should be entered here.
+            If this is also their personal email address, it should be made clear to them how the email address will be used.
+            The email address must be an up-to-date, valid, and actively monitored email address.
+            This information is not publicly displayed on the website's interface and is classed as personal data, therefore,
+            it cannot be shared publicly, for example, through a Freedom of Information (FOI) request.
+            Under the conditions of Article 6(1)(e) of the UK-GDPR this information can be shared with other government departments,
+            non-departmental public bodies, arm's length bodies and partners for official functions and tasks within the public interest to be performed.
+        </p>
+        <p>
+            This information is very important as it allows the Department for Education to share important information and messages with the governance professional.
+        </p>"
+        )
 }
 
 @helper DisplayAppointmentDates()
@@ -271,7 +435,7 @@ else
         var detail = disableStartDate ? @"(based on current governor's end date)" : $@"{startDateSaveRecord}";
         var title = $"Date of appointment {detail}";
         @Html.EditorFor(x => x.AppointmentStartDate,
-            new { title, @readonly = disableStartDate, ClassPrefix = "start-date", editorPrefix })
+            new {title, @readonly = disableStartDate, ClassPrefix = "start-date", editorPrefix})
     }
 
     if (Model.EditPolicy.AppointmentEndDate)
@@ -299,19 +463,20 @@ else
         var inputId = "appointing-body-id-textbox";
         var errorsWrapperId = $"{inputId}-errors";
         <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.AppointingBodyId)">
-            @Html.LabelFor(x => x.AppointingBodyId, "Appointing body (required to save record)", new { @class = "govuk-label" })
+            @Html.LabelFor(x => x.AppointingBodyId, "Appointing body (required to save record)", new {@class = "govuk-label"})
             <span id="@errorsWrapperId">
-                @Html.ValidationMessageFor(x => x.AppointingBodyId, null, new { @class = "govuk-error-message" })
+                @Html.ValidationMessageFor(x => x.AppointingBodyId, null, new {@class = "govuk-error-message"})
             </span>
             @Html.DropDownListFor(x => x.AppointingBodyId, Model.AppointingBodies, "",
-                new { id = "governorAppointingBodyInput", @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.AppointingBodyId)), aria_describedBy = errorsWrapperId, })
+                new {id = "governorAppointingBodyInput", @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.AppointingBodyId)), aria_describedBy = errorsWrapperId,})
         </div>
     }
 }
 
 @helper DisplayPreviousName()
 {
-    if (Model.EditPolicy.PreviousFullName)
+
+    if (Model.DisplayPolicy.PreviousFullName)
     {
         {
             var inputId = "previous-name-title-select";
@@ -326,43 +491,31 @@ else
             </div>
         }
 
-        {
-            var inputId = "previous-first-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.PreviousFirstName)">
-                @Html.LabelFor(x => x.PreviousFirstName, new { @class = "govuk-label" })
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.PreviousFirstName, null, new { @class = "govuk-error-message" })
-                </span>
-                @Html.TextBoxFor(x => x.PreviousFirstName,
-                    new { id = "GovernorPreviousNameFirstNameInput", @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.PreviousFirstName)), aria_describedBy = errorsWrapperId, })
-            </div>
-        }
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.PreviousFirstName,
+            isVisible: Model.DisplayPolicy.PreviousFullName,
+            isEditable: Model.EditPolicy.PreviousFullName,
+            isRequired: false,
+            customInputId: "previous-first-name-textbox",
+            labelText: "Previous first name"
+            )
 
-        {
-            var inputId = "previous-middle-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.PreviousMiddleName)">
-                @Html.LabelFor(x => x.PreviousMiddleName, new { @class = "govuk-label" })
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.PreviousMiddleName, null, new { @class = "govuk-error-message" })
-                </span>
-                @Html.TextBoxFor(x => x.PreviousMiddleName,
-                    new { id = "GovernorPreviousNameMiddleNameInput", @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.PreviousMiddleName)), aria_describedBy = errorsWrapperId, })
-            </div>
-        }
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.PreviousMiddleName,
+            isVisible: Model.DisplayPolicy.PreviousFullName,
+            isEditable: Model.EditPolicy.PreviousFullName,
+            isRequired: false,
+            customInputId: "previous-middle-name-textbox",
+            labelText: "Previous middle name"
+            )
 
-        {
-            var inputId = "previous-last-name-textbox";
-            var errorsWrapperId = $"{inputId}-errors";
-            <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.PreviousLastName)">
-                @Html.LabelFor(x => x.PreviousLastName, new {@class = "govuk-label"})
-                <span id="@errorsWrapperId">
-                    @Html.ValidationMessageFor(x => x.PreviousLastName, null, new {@class = "govuk-error-message"})
-                </span>
-                @Html.TextBoxFor(x => x.PreviousLastName,
-                    new {id = "GovernorPreviousNameLastNameInput", @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.PreviousLastName)), aria_describedBy = errorsWrapperId,})
-            </div>
-        }
+        @GdsStyledFormFieldTextBox(
+            expression: x => x.PreviousLastName,
+            isVisible: Model.DisplayPolicy.PreviousFullName,
+            isEditable: Model.EditPolicy.PreviousFullName,
+            isRequired: false,
+            customInputId: "previous-last-name-textbox",
+            labelText: "Previous last name"
+            )
     }
 }

--- a/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
@@ -27,7 +27,7 @@ else
 
 @helper DisplayGid()
 {
-    if (Model.DisplayPolicy.Id)
+    if (Model.EditPolicy.Id)
     {
         <div class="govuk-form-group">
             <label class="govuk-label" for="governorGidInput">
@@ -52,7 +52,7 @@ else
 
 @helper DisplayName()
 {
-    if (Model.DisplayPolicy.FullName)
+    if (Model.EditPolicy.FullName)
     {
         <div class="govuk-form-group" id="governorFullNameDiv" style="display:none">
             <label class="govuk-label" for="governorFullNameInput">
@@ -126,7 +126,7 @@ else
 
 @helper DisplayDateOfBirth()
 {
-    if (Model.DisplayPolicy.DOB)
+    if (Model.EditPolicy.DOB)
     {
         @Html.EditorFor(x => x.DOB,
             new
@@ -138,7 +138,7 @@ else
 
 @helper DisplayPostcode()
 {
-    if (Model.DisplayPolicy.PostCode)
+    if (Model.EditPolicy.PostCode)
     {
         var inputId = "governor-postcode-textbox";
         var errorsWrapperId = $"{inputId}-errors";
@@ -168,7 +168,7 @@ else
 
 @helper DisplayTelephoneNumber()
 {
-    if (Model.DisplayPolicy.TelephoneNumber)
+    if (Model.EditPolicy.TelephoneNumber)
     {
         var inputId = "governor-telephone-number-textbox";
         var errorsWrapperId = $"{inputId}-errors";
@@ -198,7 +198,7 @@ else
 
 @helper DisplayEmail()
 {
-    if (Model.DisplayPolicy.EmailAddress)
+    if (Model.EditPolicy.EmailAddress)
     {
         var labelText = "Email address";
         if (Model.GovernorRole.OneOfThese(
@@ -265,7 +265,7 @@ else
     }
     var editorPrefix = ViewData["editorPrefix"]?.ToString();
 
-    if (Model.DisplayPolicy.AppointmentStartDate)
+    if (Model.EditPolicy.AppointmentStartDate)
     {
         var startDateSaveRecord = isGovernorRole ? "(required to save record)" : "";
         var detail = disableStartDate ? @"(based on current governor's end date)" : $@"{startDateSaveRecord}";
@@ -274,7 +274,7 @@ else
             new { title, @readonly = disableStartDate, ClassPrefix = "start-date", editorPrefix })
     }
 
-    if (Model.DisplayPolicy.AppointmentEndDate)
+    if (Model.EditPolicy.AppointmentEndDate)
     {
         var titleText = Model.GovernorRole == eLookupGovernorRole.Member
             ? "Date stepped down"
@@ -294,7 +294,7 @@ else
 
 @helper DisplayAppointingBody()
 {
-    if (Model.DisplayPolicy.AppointingBodyId)
+    if (Model.EditPolicy.AppointingBodyId)
     {
         var inputId = "appointing-body-id-textbox";
         var errorsWrapperId = $"{inputId}-errors";
@@ -311,7 +311,7 @@ else
 
 @helper DisplayPreviousName()
 {
-    if (Model.DisplayPolicy.PreviousFullName)
+    if (Model.EditPolicy.PreviousFullName)
     {
         {
             var inputId = "previous-name-title-select";

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -545,7 +545,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             });
             mockControllerContext.SetupGet(c => c.RouteData).Returns(new RouteData(new Route("", new PageRouteHandler("~/")), new PageRouteHandler("~/")));
             mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(It.IsAny<CreateEditGovernorViewModel>(), estabUrn, null, It.IsAny<IPrincipal>(), It.IsAny<Action<EstablishmentModel>>(), It.IsAny<Action<GroupModel>>())).Returns(Task.CompletedTask);
-            mockGovernorsReadService.Setup(g => g.GetEditorDisplayPolicyAsync(eLookupGovernorRole.ChairOfGovernors, false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorDisplayPolicy());
+            mockGovernorsReadService.Setup(g => g.GetEditPolicyAsync(eLookupGovernorRole.ChairOfGovernors, false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorEditPolicy());
 
             var result = await controller.AddEditOrReplace(null, estabUrn, eLookupGovernorRole.ChairOfGovernors, null);
 
@@ -574,7 +574,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             mockControllerContext.SetupGet(c => c.RouteData).Returns(new RouteData(new Route("", new PageRouteHandler("~/")), new PageRouteHandler("~/")));
             mockGovernorsReadService.Setup(g => g.GetGovernorAsync(governorId, It.IsAny<IPrincipal>())).ReturnsAsync(() => governor);
             mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(It.IsAny<CreateEditGovernorViewModel>(), estabUrn, null, It.IsAny<IPrincipal>(), It.IsAny<Action<EstablishmentModel>>(), It.IsAny<Action<GroupModel>>())).Returns(Task.CompletedTask);
-            mockGovernorsReadService.Setup(g => g.GetEditorDisplayPolicyAsync(eLookupGovernorRole.Governor, false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorDisplayPolicy());
+            mockGovernorsReadService.Setup(g => g.GetEditPolicyAsync(eLookupGovernorRole.Governor, false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorEditPolicy());
 
             var result = await controller.AddEditOrReplace(null, estabUrn, null, 1032);
 
@@ -1045,7 +1045,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             var errorMessage = "test message";
 
 
-            mockGovernorsReadService.Setup(g => g.GetEditorDisplayPolicyAsync(It.IsAny<eLookupGovernorRole>(), It.IsAny<bool>(), It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorDisplayPolicy());
+            mockGovernorsReadService.Setup(g => g.GetEditPolicyAsync(It.IsAny<eLookupGovernorRole>(), It.IsAny<bool>(), It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorEditPolicy());
             mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(It.IsAny<CreateEditGovernorViewModel>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<IPrincipal>(), It.IsAny<Action<EstablishmentModel>>(), It.IsAny<Action<GroupModel>>())).Returns(Task.CompletedTask);
             mockGovernorsWriteService
                 .Setup(g => g.ValidateAsync(It.IsAny<GovernorModel>(), It.IsAny<IPrincipal>()))
@@ -1096,7 +1096,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             mockGovernorsReadService.Setup(g => g.GetGovernorListAsync(It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<IPrincipal>())).ReturnsAsync(() => governorDetailsDto);
             mockGovernorsReadService.Setup(g => g.GetGovernorAsync(gid, It.IsAny<IPrincipal>())).ReturnsAsync(() => governor);
             mockGovernorsReadService.Setup(g => g.GetSharedGovernorsAsync(estabId, It.IsAny<IPrincipal>())).ReturnsAsync(() => new List<GovernorModel>());
-            mockGovernorsReadService.Setup(g => g.GetEditorDisplayPolicyAsync(It.IsAny<eLookupGovernorRole>(), false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorDisplayPolicy());
+            mockGovernorsReadService.Setup(g => g.GetEditPolicyAsync(It.IsAny<eLookupGovernorRole>(), false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorEditPolicy());
             mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(It.IsAny<ReplaceChairViewModel>(), estabId, null, It.IsAny<IPrincipal>(), It.IsAny<Action<EstablishmentModel>>(), It.IsAny<Action<GroupModel>>())).Returns(Task.CompletedTask);
 
 
@@ -1230,7 +1230,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
 
             mockGovernorsReadService.Setup(g => g.GetGovernorAsync(model.ExistingGovernorId, It.IsAny<IPrincipal>())).ReturnsAsync(() => existingGov);
             mockGovernorsReadService.Setup(g => g.GetSharedGovernorsAsync(estabUrn, It.IsAny<IPrincipal>())).ReturnsAsync(() => new List<GovernorModel>());
-            mockGovernorsReadService.Setup(g => g.GetEditorDisplayPolicyAsync(It.IsAny<eLookupGovernorRole>(), false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorDisplayPolicy());
+            mockGovernorsReadService.Setup(g => g.GetEditPolicyAsync(It.IsAny<eLookupGovernorRole>(), false, It.IsAny<IPrincipal>())).ReturnsAsync(() => new GovernorEditPolicy());
             mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(It.IsAny<ReplaceChairViewModel>(), estabUrn, null, It.IsAny<IPrincipal>(), It.IsAny<Action<EstablishmentModel>>(), It.IsAny<Action<GroupModel>>())).Returns(Task.CompletedTask);
 
 


### PR DESCRIPTION
This is a draft for now, as it would conflict with other commits in this area.

Also, this is currently targeted at the governance professional branch, but this will apply more broadly.


**Changes**

- Rename calls to fetch the edit policy, to explicitly indicate it is fetching the edit policy 
  - Previously: `viewModel.DisplayPolicy = await _governorsReadService.GetEditorDisplayPolicyAsync(role.Value, groupUId.HasValue, User);`  
  - ... which fetches the edit policy
    ```csharp
            public async Task<GovernorDisplayPolicy> GetEditorDisplayPolicyAsync(eLookupGovernorRole role, bool isGroup, IPrincipal principal)
            => (await _httpClient.GetAsync<GovernorDisplayPolicy>($"governor/{(int)role}/edit-policy?isForGroup={isGroup.ToString().ToLower()}", principal)).GetResponse();
    ```
- Use the (actual) display and edit policies to conditionally display inputs on the edit form
  - Allows for readable fields to be visible, but disabled (consistent with other edit forms)
- Template text inputs
  - Currently via a `@helper`, but likely better suited to a view model (similar to the date time one)