### PR TITLE
Secure 16 19 groups

### DIFF
--- a/Web/Edubase.Services/Enums/eLookupGroupType.cs
+++ b/Web/Edubase.Services/Enums/eLookupGroupType.cs
@@ -11,6 +11,7 @@ namespace Edubase.Services.Enums
         SingleacademyTrust = 10,
         Trust = 2,
         UmbrellaTrust = 7,
+        SecureSingleAcademyTrust = 11
     }
 
 }

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/CreateEdit/CreateAcademyTrustViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/CreateEdit/CreateAcademyTrustViewModel.cs
@@ -1,5 +1,6 @@
 using Edubase.Common;
 using Edubase.Services.Domain;
+using Edubase.Services.Enums;
 using Edubase.Services.IntegrationEndPoints.CompaniesHouse.Models;
 using System;
 using System.Collections.Generic;
@@ -13,6 +14,13 @@ namespace Edubase.Web.UI.Areas.Groups.Models.CreateEdit
 {
     public class CreateAcademyTrustViewModel
     {
+        private static readonly Dictionary<int?, string> GroupTypeName = new Dictionary<int?, string>()
+        {
+            { (int) eLookupGroupType.MultiacademyTrust, "multi-academy trust" },
+            { (int) eLookupGroupType.SingleacademyTrust, "single-academy trust" },
+            { (int) eLookupGroupType.SecureSingleAcademyTrust, "secure single-academy trust" }
+        };
+
         public CreateAcademyTrustViewModel(CompanyProfile companyProfile)
         {
             Name = companyProfile.Name;
@@ -54,6 +62,6 @@ namespace Edubase.Web.UI.Areas.Groups.Models.CreateEdit
 
         public string CompaniesHouseAddressToken { get; set; }
 
-
+        public string TypeName => TypeId != null ? GroupTypeName[TypeId] : null;
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/CreateEdit/SearchCompaniesHouseModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/CreateEdit/SearchCompaniesHouseModel.cs
@@ -15,7 +15,7 @@ namespace Edubase.Web.UI.Areas.Groups.Models.CreateEdit
         public int StartIndex { get; set; }
         public int PageSize { get; set; } = 50;
         
-        public int Count => Results.Count;
+        public int Count => Results?.Count ?? 0;
         public int PageCount => (int)Math.Ceiling(Count / (double)PageSize);
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
@@ -41,7 +41,7 @@
             @if (Model.TrustExists == true)
             {
                 <div role="alert" class="warning-message js-trigger-aria-live">
-                    <p id="create-academy-trust-warning-message" class="message-text" aria-live="polite">Company is already a @(Model.TypeId == (int)eLookupGroupType.MultiacademyTrust? "multi-academy" : "single-academy") trust</p>
+                    <p id="create-academy-trust-warning-message" class="message-text" aria-live="polite">Company is already a @(Model.TypeName)</p>
                 </div>
             }
             else
@@ -77,7 +77,7 @@
                     </div>
                 </dl>
 
-                <p>@Html.ActionLink("Wrong company?", "SearchCompaniesHouse", "Group", new {area = "Groups"}, new { @class = "change-link" })</p>
+                <p>@Html.ActionLink("Wrong company?", "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new { @class = "change-link" })</p>
             </div>
 
             @Html.HiddenFor(x => x.CompaniesHouseAddressToken)
@@ -104,7 +104,7 @@
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">Trust type</dt>
                             <dd class="govuk-summary-list__value">
-                                @Model.GroupTypes.First(x => x.Value.Equals(Model.TypeId?.ToString(), StringComparison.InvariantCultureIgnoreCase)).Text
+                                @Model.TypeName
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row">
@@ -140,7 +140,7 @@
             <div class="button-row">
             @if (Model.TrustExists == true)
             {
-                @Html.ActionLink("Back to company search", "SearchCompaniesHouse", "Group", new {area = "Groups"}, new {@class = "govuk-button cancel"})
+                @Html.ActionLink("Back to company search", "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new {@class = "govuk-button cancel"})
             }
             else
             {

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
@@ -33,7 +33,7 @@
 </div>
 
 
-@using (Html.BeginForm("SaveNewAcademyTrust", "Group", new { area = "Groups" }, FormMethod.Post))
+@using (Html.BeginForm("SaveNewAcademyTrust", "Group", new { area = "Groups", groupTypeName = ViewData["groupTypeName"] }, FormMethod.Post))
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -144,7 +144,7 @@
             }
             else
             {
-                @Html.ActionLink(HttpUtility.HtmlDecode("&laquo; Go back"), "SearchCompaniesHouse", "Group", new {area = "Groups"}, new {@class = "govuk-button govuk-button--secondary cancel"})
+                @Html.ActionLink(HttpUtility.HtmlDecode("&laquo; Go back"), "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new {@class = "govuk-button govuk-button--secondary cancel"})
                 if (Model.AllowSave)
                 {
                     <button type="submit" id="create-academy-trust-submit-button" class="govuk-button submit">Create academy trust</button>

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/CreateAcademyTrust.cshtml
@@ -33,7 +33,7 @@
 </div>
 
 
-@using (Html.BeginForm("SaveNewAcademyTrust", "Group", new { area = "Groups", groupTypeName = ViewData["groupTypeName"] }, FormMethod.Post))
+@using (Html.BeginForm("SaveNewAcademyTrust", "Group", new { area = "Groups", academyTrustRoute = ViewData["academyTrustRoute"] }, FormMethod.Post))
 {
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -77,7 +77,7 @@
                     </div>
                 </dl>
 
-                <p>@Html.ActionLink("Wrong company?", "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new { @class = "change-link" })</p>
+                <p>@Html.ActionLink("Wrong company?", "SearchCompaniesHouse", "Group", new {area = "Groups", academyTrustRoute = ViewData["academyTrustRoute"] }, new { @class = "change-link" })</p>
             </div>
 
             @Html.HiddenFor(x => x.CompaniesHouseAddressToken)
@@ -140,11 +140,11 @@
             <div class="button-row">
             @if (Model.TrustExists == true)
             {
-                @Html.ActionLink("Back to company search", "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new {@class = "govuk-button cancel"})
+                @Html.ActionLink("Back to company search", "SearchCompaniesHouse", "Group", new {area = "Groups", academyTrustRoute = ViewData["academyTrustRoute"] }, new {@class = "govuk-button cancel"})
             }
             else
             {
-                @Html.ActionLink(HttpUtility.HtmlDecode("&laquo; Go back"), "SearchCompaniesHouse", "Group", new {area = "Groups", groupTypeName = ViewData["groupTypeName"] }, new {@class = "govuk-button govuk-button--secondary cancel"})
+                @Html.ActionLink(HttpUtility.HtmlDecode("&laquo; Go back"), "SearchCompaniesHouse", "Group", new {area = "Groups", academyTrustRoute = ViewData["academyTrustRoute"] }, new {@class = "govuk-button govuk-button--secondary cancel"})
                 if (Model.AllowSave)
                 {
                     <button type="submit" id="create-academy-trust-submit-button" class="govuk-button submit">Create academy trust</button>

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
@@ -289,7 +289,7 @@
 
                         </div>
 
-                        @if (Model.Group.GroupTypeId == (int)eLookupGroupType.MultiacademyTrust)
+                        @if (Model.Group.GroupTypeId == (int)eLookupGroupType.MultiacademyTrust || Model.Group.GroupTypeId == (int)eLookupGroupType.SecureSingleAcademyTrust)
                         {
                             <div id="governance" class="tab-content">
 

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/SearchCompaniesHouse.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/SearchCompaniesHouse.cshtml
@@ -84,7 +84,7 @@
                         @foreach (var result in Model.Results.Items)
                         {
                             <tr class="govuk-table__row">
-                                <td data-label="Name" class="govuk-table__cell">@Html.ActionLink(result.Name, "CreateAcademyTrust", "Group", new { companiesHouseNumber = result.Number, area = "Groups" }, null)</td>
+                                <td data-label="Name" class="govuk-table__cell">@Html.ActionLink(result.Name, "CreateAcademyTrust", "Group", new { companiesHouseNumber = result.Number, area = "Groups", groupTypeName = ViewData["groupTypeName"] }, null)</td>
                                 <td data-label="Companies House number" class="govuk-table__cell"><a href="@System.Configuration.ConfigurationManager.AppSettings["CompaniesHouseBaseUrl"]@result.Number" target="_blank">@result.Number (opens in new tab)</a></td>
                                 <td data-label="Date incorporated" class="govuk-table__cell">@(result.IncorporationDate?.ToString("d MMMM yyyy"))</td>
                                 <td data-label="Address" class="govuk-table__cell">@(result.Address.ToString() ?? "Not recorded")</td>

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/SearchCompaniesHouse.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/SearchCompaniesHouse.cshtml
@@ -84,7 +84,7 @@
                         @foreach (var result in Model.Results.Items)
                         {
                             <tr class="govuk-table__row">
-                                <td data-label="Name" class="govuk-table__cell">@Html.ActionLink(result.Name, "CreateAcademyTrust", "Group", new { companiesHouseNumber = result.Number, area = "Groups", groupTypeName = ViewData["groupTypeName"] }, null)</td>
+                                <td data-label="Name" class="govuk-table__cell">@Html.ActionLink(result.Name, "CreateAcademyTrust", "Group", new { companiesHouseNumber = result.Number, area = "Groups", academyTrustRoute = ViewData["academyTrustRoute"] }, null)</td>
                                 <td data-label="Companies House number" class="govuk-table__cell"><a href="@System.Configuration.ConfigurationManager.AppSettings["CompaniesHouseBaseUrl"]@result.Number" target="_blank">@result.Number (opens in new tab)</a></td>
                                 <td data-label="Date incorporated" class="govuk-table__cell">@(result.IncorporationDate?.ToString("d MMMM yyyy"))</td>
                                 <td data-label="Address" class="govuk-table__cell">@(result.Address.ToString() ?? "Not recorded")</td>

--- a/Web/Edubase.Web.UI/Controllers/ToolsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/ToolsController.cs
@@ -64,6 +64,8 @@ namespace Edubase.Web.UI.Controllers
                 UserCanCreateChildrensCentreGroup = createGroupPermission.GroupTypes.Any(x => x == GT.ChildrensCentresCollaboration || x == GT.ChildrensCentresGroup),
                 UserCanCreateFederationGroup = createGroupPermission.GroupTypes.Any(x => x == GT.Federation),
                 UserCanCreateSchoolTrustGroup = createGroupPermission.GroupTypes.Any(x => x == GT.Trust),
+                //TODO below is a hack to make this work as currently this is not returned from the java api security/group/create-permission
+                UserCanCreateSecureSingleAcademyTrustGroup = true,//createGroupPermission.GroupTypes.Any(x => x == GT.SecureSingleAcademyTrust),
                 UserCanCreateAcademySponsor = createGroupPermission.GroupTypes.Any(x => x == GT.SchoolSponsor),
                 UserCanCreateEstablishment = createEstablishmentPermission.CanCreate,
                 UserCanManageAcademyOpenings = User.InRole(AuthorizedRoles.CanManageAcademyOpenings),

--- a/Web/Edubase.Web.UI/Controllers/ToolsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/ToolsController.cs
@@ -64,8 +64,7 @@ namespace Edubase.Web.UI.Controllers
                 UserCanCreateChildrensCentreGroup = createGroupPermission.GroupTypes.Any(x => x == GT.ChildrensCentresCollaboration || x == GT.ChildrensCentresGroup),
                 UserCanCreateFederationGroup = createGroupPermission.GroupTypes.Any(x => x == GT.Federation),
                 UserCanCreateSchoolTrustGroup = createGroupPermission.GroupTypes.Any(x => x == GT.Trust),
-                //TODO below is a hack to make this work as currently this is not returned from the java api security/group/create-permission
-                UserCanCreateSecureSingleAcademyTrustGroup = true,//createGroupPermission.GroupTypes.Any(x => x == GT.SecureSingleAcademyTrust),
+                UserCanCreateSecureSingleAcademyTrustGroup = createGroupPermission.GroupTypes.Any(x => x == GT.SecureSingleAcademyTrust),
                 UserCanCreateAcademySponsor = createGroupPermission.GroupTypes.Any(x => x == GT.SchoolSponsor),
                 UserCanCreateEstablishment = createEstablishmentPermission.CanCreate,
                 UserCanManageAcademyOpenings = User.InRole(AuthorizedRoles.CanManageAcademyOpenings),

--- a/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
@@ -19,6 +19,7 @@ namespace Edubase.Web.UI.Models
         public bool UserCanCreateAcademyTrustGroup { get; set; }
         public bool UserCanCreateFederationGroup { get; set; }
         public bool UserCanCreateSchoolTrustGroup { get; set; }
+        public bool UserCanCreateSecureSingleAcademyTrustGroup { get; set; }
         public bool UserCanCreateAcademySponsor { get; set; }
 
         public bool UserCanCreateEstablishment { get; set; }

--- a/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
@@ -84,12 +84,16 @@ namespace Edubase.Web.UI.Models
 
             if (UserCanCreateAcademyTrustGroup)
             {
-                retVal.Add(new LinkAction { Link = htmlHelper.ActionLink("Create new academy trusts", "SearchCompaniesHouse", "Group", new { area = "Groups" }, null), Description = "Set up a new academy trust record." });
+                retVal.Add(new LinkAction { Link = htmlHelper.ActionLink("Create new academy trusts", "SearchCompaniesHouse", "Group", new { area = "Groups", groupTypeName = "academy-trust" }, null), Description = "Set up a new academy trust record." });
             }
 
             if (UserCanConvertAcademyTrusts)
             {
                 retVal.Add(new LinkAction { Link = htmlHelper.RouteLink("Convert single-academy trusts (SATs)", "GroupConvertSAT2MAT"), Description = "Convert a single-academy trust (SAT) record to a multi-academy trust (MAT) record." });
+            }
+            if (UserCanCreateSecureSingleAcademyTrustGroup)
+            {
+                retVal.Add(new LinkAction {  Link = htmlHelper.ActionLink("Create new Secure Single-academy trust", "SearchCompaniesHouse", "Group", new { area = "Groups", groupTypeName = "secure-academy-trust"}, null), Description = "Set up a new secure single-academy trust record." });
             }
 
             return retVal;

--- a/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
@@ -84,7 +84,7 @@ namespace Edubase.Web.UI.Models
 
             if (UserCanCreateAcademyTrustGroup)
             {
-                retVal.Add(new LinkAction { Link = htmlHelper.ActionLink("Create new academy trusts", "SearchCompaniesHouse", "Group", new { area = "Groups", groupTypeName = "academy-trust" }, null), Description = "Set up a new academy trust record." });
+                retVal.Add(new LinkAction { Link = htmlHelper.ActionLink("Create new academy trusts", "SearchCompaniesHouse", "Group", new { area = "Groups", academyTrustRoute = "academy-trust" }, null), Description = "Set up a new academy trust record." });
             }
 
             if (UserCanConvertAcademyTrusts)
@@ -93,7 +93,7 @@ namespace Edubase.Web.UI.Models
             }
             if (UserCanCreateSecureSingleAcademyTrustGroup)
             {
-                retVal.Add(new LinkAction {  Link = htmlHelper.ActionLink("Create new Secure Single-academy trust", "SearchCompaniesHouse", "Group", new { area = "Groups", groupTypeName = "secure-academy-trust"}, null), Description = "Set up a new secure single-academy trust record." });
+                retVal.Add(new LinkAction {  Link = htmlHelper.ActionLink("Create new Secure Single-academy trust", "SearchCompaniesHouse", "Group", new { area = "Groups", academyTrustRoute = "secure-academy-trust"}, null), Description = "Set up a new secure single-academy trust record." });
             }
 
             return retVal;

--- a/Web/Edubase.Web.UIUnitTests/Areas/Groups/Controllers/GroupControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Groups/Controllers/GroupControllerTests.cs
@@ -909,7 +909,7 @@ namespace Edubase.Web.UI.Areas.Groups.Controllers.UnitTests
                 OpenDate = DateTime.Now,
                 GroupId = "54243"
             };
-            var result = (RedirectToRouteResult) await controller.SaveNewAcademyTrust(vm);
+            var result = (RedirectToRouteResult) await controller.SaveNewAcademyTrust(vm,"academy-trust");
             Assert.Equal("Details", result.RouteValues["action"]);
             Assert.Equal(123, result.RouteValues["id"]);
         }


### PR DESCRIPTION
Uses a new link on the 'tools' page to enable creation of a secure single-academy trust, if the user has permission to do so.

Introduced a academyTrustRoute parameter to the controller endpoints to track whether we're creating a secure academy trust, or a normal academy trust, to enable the re-use of the same code.