### PR TITLE
Add comments and documentation about configuration options within `Web.config`

### DIFF
--- a/Web/.editorconfig
+++ b/Web/.editorconfig
@@ -18,6 +18,12 @@ charset = utf-8
 [*.{js,scss,vue}]
 indent_size = 2
 
+[Web.config]
+indent_size = 2
+
+[*.csproj]
+indent_size = 2
+
 ########################################################################################################################
 # .NET Coding Conventions                                                                                              #
 # Reference: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017 #

--- a/Web/Edubase.Web.UI/Global.asax.cs
+++ b/Web/Edubase.Web.UI/Global.asax.cs
@@ -28,7 +28,8 @@ namespace Edubase.Web.UI
 #if DEBUG
             try
             {
-                GetExternalSettings();
+                const string pathToConfigFile = "../../devsecrets.gias.config.alwaysignore";
+                GetExternalSettings(pathToConfigFile);
             }
             catch
             {
@@ -68,9 +69,9 @@ namespace Edubase.Web.UI
         }
 
 
-        private static void GetExternalSettings()
+        private static void GetExternalSettings(string pathToConfigFile)
         {
-            string configPath = Path.Combine(AppContext.BaseDirectory, "../../devsecrets.gias.config.alwaysignore");
+            string configPath = Path.Combine(AppContext.BaseDirectory, pathToConfigFile);
             if (!File.Exists(configPath))
             {
                 throw new FileNotFoundException();

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -23,48 +23,110 @@
 
   <connectionStrings>
     <!--
-        Connection string to the GIAS website's Azure Storage account
-        - Table storage
-        - Blob storage
+      Connection string to the GIAS website's Azure Storage account
+      - Table storage
+      - Blob storage
 
-        Note that the API typically uses a different Azure Storage account
-        to serve e.g., pre-generated extracts/downloads.
+      Note that the API typically uses a different Azure Storage account
+      to serve e.g., pre-generated extracts/downloads.
     -->
     <add name="DataConnectionString" connectionString="" />
 
     <!--
-        The GIAS website makes (limited) use of Redis caches to minimise the number of API requests made.
-        This is in combination with a variety of in-memory caches.
+      The GIAS website makes (limited) use of Redis caches to minimise the number of API requests made.
+      This is in combination with a variety of in-memory caches.
 
-        GIAS's caching strategy is for review, and this may be removed at a later date.
+      GIAS's caching strategy is for review, and this may be removed at a later date.
     -->
     <add name="Redis" connectionString="" />
   </connectionStrings>
   <appSettings>
-    <!-- ==== SERVER / WEBSITE CONFIGURATION ==== -->
 
+    <!-- ==== SERVER / WEBSITE CONFIGURATION ==== -->
     <!--
       The 'Environment` setting is used as a descriptor for the environment in which the application is running.
       - When running locally, this value should be set to 'localdev' (some local-specific options rely on this).
     -->
     <add key="Environment" value="localdev" />
 
+    <!--
+      TBC, Potentially unused, replaced by filter and `EnableFriendlyErrorPage`(?)
+      See also: Edubase.Web.UI.MvcApplication.Application_Error
+    -->
     <add key="EnableErrorReporting" value="true" />
+
+    <!--
+      A "friendly" error page is one which hides the technical detail / stack trace.
+
+      By default this is `true` as stack traces and other technical detail are not appropriate
+      to include within user-facing errors, however overriding this within local/dev environments
+      for debugging/testing purposes is likely desirable.
+
+      See also: Edubase.Web.UI.Filters.ExceptionHandler.OnException
+    -->
     <add key="EnableFriendlyErrorPage" value="true" />
 
+    <!--
+      Razor engine version (e.g., MVC3 users Razor v3)
+
+      See also: https://devblogs.microsoft.com/dotnet/how-does-vs-determine-which-version-of-razor-engine-to-use-when-editing-razor-webpage-files.aspx
+    -->
     <add key="webpages:Version" value="3.0.0.0" />
+
+    <!--
+      Setting `webpages:Enabled` to `false` prevents direct access of e.g., `.cshtml` files
+    -->
     <add key="webpages:Enabled" value="false" />
 
 
     <!-- ==== GIAS WEBSITE DEBUGGING ==== -->
+    <!--
+      TBC - Used by Glimpse? (debugging tool)
+    -->
     <add key="ApiTraceSessionRetentionCount" value="25" />
+
+    <!--
+      Debugging utility to inspect routes available and routes potentially matching the current page
+
+      This is disabled by default (`false`), though enabling it (`true`) locally for debug/test purposes may be desirable.
+
+      See also: https://haacked.com/archive/2008/03/13/url-routing-debugger.aspx/
+    -->
     <add key="RouteDebugger:Enabled" value="false" />
+
+    <!--
+      API Logging records the HTTP requests and responses made to the API.
+      If enabled, these logs are placed within Azure Table Storage.
+      These logs are associated with
+      - the `SaUserId` for logged in users, or
+      - the cookie value of `ApiSessionId` for not-logged-in users
+
+      WARNING: These logs are highly detailed and contain sensitive data
+      (e.g., HTTP headers, including authorisation headers), therefore
+      must not routinely be enabled in production.
+
+      If this is enabled in production-like environment, access to the log data
+      *must* be monitored, and the data must be removed as soon as reasonably practical.
+    -->
     <add key="EnableApiLogging" value="false" />
 
 
     <!-- ==== GIAS WEBSITE FUNCTIONALITY CONFIGURATION ==== -->
+    <!--
+      This is the maximum permitted age (in days) of a data quality check,
+      before users will be prompted again.
+    -->
     <add key="DataQualityUpdatePeriod" value="7" />
 
+    <!--
+      Sitemaps are accessed by e.g., search engine bots to index the website.
+      - `SitemapCacheDays`      The maximum age of a generated and cached (in-memory) sitemap file (days)
+      - `SitemapExcludeApi`     Misleadingly named - API routes (used by JavaScript) will be
+                                - excluded from the sitemap where this value is set to value `0` (a normally falsey value), and
+                                - included in the sitemap when value is set to `1` (or any other non-zero int, a normally truthy value)
+
+      See also: Edubase.Web.UI.Controllers.SitemapController.ExcludeApiLookup
+    -->
     <add key="SitemapCacheDays" value="21" />
     <add key="SitemapExcludeApi" value="0" />
 
@@ -74,16 +136,31 @@
 
 
     <!-- ==== JAVASCRIPT API KEYS ==== -->
+    <!--
+      API Keys
+      - `GoogleApiKeyClientSide`    Analytics of access to the GIAS website (details TBC)
+      - `GoogleTagManagerKey`       Analytics of access to the GIAS website (details TBC)
+      - `AzureMapsApiKey`           Maps are displayed on the search results and some establishment detail pages
+      - `OSPlacesApiKey`            Auto-complete functionality on Azure Maps (TBC)
+    -->
     <add key="GoogleApiKeyClientSide" value="" />
     <add key="GoogleTagManagerKey" value="" />
     <add key="AzureMapsApiKey" value="" />
     <add key="OSPlacesApiKey" value="" />
 
+    <!-- TBC -->
     <add key="ClientValidationEnabled" value="false" />
+    <!-- TBC -->
     <add key="UnobtrusiveJavaScriptEnabled" value="false" />
 
 
     <!-- ==== GIAS API DEPENDENCIES ==== -->
+    <!--
+      Data presented via the GIAS website and changes made by GIAS website users is normally
+      provided by the backend API.
+      Note: Do not supply username/password (or other secrets) directly here.
+      Specify this via app config on Azure, or via dev secrets if running locally.
+    -->
     <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
@@ -94,15 +171,57 @@
 
 
     <!-- ==== 3RD PARTY API DEPENDENCIES ==== -->
+    <!--
+      Academies are registered businesses, and some information about those businesses are made visible within GIAS.
+      Companies House supply those business/company details via the API.
+    -->
     <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/" />
     <add key="CompaniesHouseApiKey" value="" />
 
+    <!--
+      The Schools Financial Benchmarking (SFB) service provides data
+      about education establishments and Academy Trusts.
+
+      Where a SFB record exists for an establishment/academy trust, GIAS provides a link to that page.
+
+      This configuration defines the website where the link points at, and for how long
+      GIAS should cache the check to see if SFB contains data about that establishment.
+
+      - `FinancialBenchmarkingURL`            URL linked to from the GIAS home page
+      - `FinancialBenchmarkingApiURL`         Base URL linked to from establishment/MAT details pages
+      - `FinancialBenchmarkingCacheHours`     GIAS only shows the establishment/MAT-specific link if GIAS has been able to
+                                              confirm that the associated FSCPD page exists.
+                                              This setting configures the maximum age of the check result.
+      - `FinancialBenchmarkingUsername`       (Not normally supplied) Basic auth username to access the FSB service.
+      - `FinancialBenchmarkingPassword`       (Not normally supplied) Basic auth username to access the FSB service.
+
+      See also: https://schools-financial-benchmarking.service.gov.uk/
+    -->
     <add key="FinancialBenchmarkingURL" value="https://as-t1dv-sfb.azurewebsites.net/" />
     <add key="FinancialBenchmarkingApiURL" value="https://aa-t1dv-sfb.azurewebsites.net/" />
     <add key="FinancialBenchmarkingCacheHours" value="72" />
     <add key="FinancialBenchmarkingUsername" value="" />
     <add key="FinancialBenchmarkingPassword" value="" />
 
+    <!--
+      The Find School and College Performance Data (FSCPD) service provides data
+      about education establishments and Multi-Academy Trusts (MATs).
+
+      Where a FSCPD record exists for an establishment, GIAS provides a link to that page.
+      This configuration defines the website where the link points at, and for how long
+      GIAS should cache the check to see if FSCPD contains data about that establishment.
+
+      See also: https://www.gov.uk/school-performance-tables
+      See also: https://www.find-school-performance-data.service.gov.uk
+
+      - `FscpdHomeUrl`      URL linked to from the GIAS home page
+      - `FscpdURL`          Base URL linked to from establishment/MAT details pages
+      - `FscpdCacheHours`   GIAS only shows the establishment/MAT-specific link if GIAS has been able to
+                            confirm that the associated FSCPD page exists.
+                            This setting configures the maximum age of the check result.
+      - `FscpdUsername`     (Not normally supplied) Basic auth username to access the FSCPD service.
+      - `FscpdPassword`     (Not normally supplied) Basic auth username to access the FSCPD service.
+    -->
     <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
     <add key="FscpdURL" value="https://cscp-dev-web.azurewebsites.net/" />
     <add key="FscpdCacheHours" value="72" />
@@ -111,20 +230,61 @@
 
 
     <!-- ==== WEBSITE AUTHENTICATION / AUTHORISATION ==== -->
+    <!--
+      ACCESS TO THE SERVER THAT GIAS IS HOSTED UPON
+
+      Non-Production and non-local instances of the Web UI should not be openly visible to the world.
+      - `HttpAuthModule.AuthMode`      Value of `Basic` enables use of "Basic authorisation" username/password access
+      - `HttpAuthModule.Credentials`   Value in format of `username:password` (with an Auth Mode of `Basic`)
+
+      See also: the <httpAuthModule> section below, within the file `Web.config`.
+  -->
     <add key="HttpAuthModuleEnabled" value="true" />
     <add key="HttpAuthModule.AuthMode" value="Basic" />
     <add key="HttpAuthModule.Realm" value="Edubase" />
 <!-- <add key="HttpAuthModule.Credentials" value="" /> -->
     <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1" />
 
-    <!-- owin:appStartup: SASimulatorConfiguration || SecureAccessConfiguration -->
+    <!--
+      ACCESS TO INTERACT WITH DATA HELD BY GIAS
+
+      Logging in to the GIAS website and the API is via data/claims sourced from a SAML(?) provider.
+      - Currently this is DfE Sign In (DSI), though a DSI Simulator
+      - Previous incarnations of GIAS include "Secure Access" (SA), whose legacy initials are
+        refrenced by some variable names e.g., "SA User ID" and `SA Simulator`
+
+      Toggling between options is specified via `owin:appStartup` (configurations for each are below)
+      - `SecureAccessConfiguration`   Use of DSI
+      - `SASimulatorConfiguration`    Use of the DSI Simualator
+    -->
     <add key="owin:appStartup" value="SASimulatorConfiguration" />
-    <!--  STAGE config / DfE Signin; used by SecureAccessConfiguration-->
+
+    <!--
+      SA/DSI configuration
+      - `ApplicationIdpEntityId`          The Entity ID of the SAML(?) provider.
+      - `ExternalAuthDefaultCallbackUrl`  The URL the Identity Provider (IDP) will redirect to after a successful login,
+                                            where the token will be recieved and processed by the GIAS website.
+      - `MetadataLocation`                The URL to the Identity Provider (IDP) metadata file.
+      - `SessionExpireTimeSpan`           The duration (hh:MM:ss) for which the session cookie remains valid,
+                                            - specifically the `Expires/Max-Age` field on the cookie.
+                                            - See also: Edubase.Web.UI.StartupSecureAccess.ConfigureAuth
+    -->
     <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase" />
     <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback" />
     <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata" />
     <add key="SessionExpireTimeSpan" value="00:59:00" />
 
+    <!--
+      SA/DSI Simulator configuration
+      - `SASimulatorUri`   the base URL for the instance of the SA/DSI Simulator
+      - `SASimulatorGuid`  the GUID for "your application's" simulator configuration (pre-configured users)
+
+      Notes:
+      - The simulator URL will be `{SASimulatorUri}{SASimulatorGuid}?{lots of SAML request bits}`
+        - e.g., https://dfe-sign-in-simulator.azurewebsites.net/{GUID-123-abc}/?SAMLRequest=
+      - It can be managed via the url `{SASimulatorUri}{SASimulatorGuid}/Manage`
+        - e.g., https://dfe-sign-in-simulator.azurewebsites.net/{GUID-123-abc}/Manage
+    -->
     <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/" />
     <add key="SASimulatorGuid" value="" />
 

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Do not edit connection string / app settings in this file directly.
+  ===================================================================
+  Instead, to specify custom values for configuration options / connection strings:
+  - On Azure: specify application configuration options
+  - Locally:  update your local config file / secrets
+-->
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -340,9 +348,9 @@
     <validation validateIntegratedModeConfiguration="false" />
   </system.webServer>
   <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd">
-    <!-- 
+    <!--
           For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
-          or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you. 
+          or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you.
       -->
   </glimpse>
   <httpAuthModule>
@@ -368,12 +376,12 @@
       - 127.0.0.1 (equals to 127.0.0.1/32)
       - 2001:0db8:bd05:01d2:288a:1fc0:0001:0000/16
       - ::1 (equals to ::1/128)
-      
+
       e.g) 127.0.0.1;182.249.0.0/16;182.248.112.128/26;::1 -->
     <!-- <add key="RestrictIPAddresses" value="127.0.0.1;::1"/> -->
     <!-- [optional] If set, specified pattern url requests are skipped by http auth and IP Restriction. -->
     <!-- <add key="IgnorePathRegex" value="^/Home/Ignore$|^/Ignore\.aspx$|^/Content/"/> -->
-    <!-- 
+    <!--
       [optional] If set,specified IPs requests skip http auth Restriction.
       value format is same as 'RestrictIPAddresses'
     -->

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -15,61 +15,89 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <section name="httpAuthModule" type="System.Configuration.NameValueFileSectionHandler" />
   </configSections>
+
   <connectionStrings>
     <add name="DataConnectionString" connectionString="" />
     <add name="Redis" connectionString="" />
   </connectionStrings>
+
   <appSettings>
+    <!--
+      The 'Environment` setting is used as a descriptor for the environment in which the application is running.
+      - When running locally, this value should be set to 'localdev' (some local-specific options rely on this).
+    -->
     <add key="Environment" value="localdev" />
+
+    <add key="DataQualityUpdatePeriod" value="7" />
+
     <add key="EnableErrorReporting" value="true" />
-    <add key="EnableFriendlyErrorPage" value="false" />
+    <add key="EnableFriendlyErrorPage" value="true" />
+
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
-    <add key="ClientValidationEnabled" value="false" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="false" />
-    <add key="CompaniesHouseApiKey" value="" />
+
     <add key="GoogleApiKeyClientSide" value="" />
     <add key="GoogleTagManagerKey" value="" />
     <add key="AzureMapsApiKey" value="" />
-    <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/" />
-    <add key="HttpAuthModule.AuthMode" value="Basic" />
-    <add key="HttpAuthModule.Realm" value="Edubase" />
-    <add key="HttpAuthModule.Credentials" value="" />
-    <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1" />
-    <add key="HttpAuthModuleEnabled" value="true" />
-    <add key="RouteDebugger:Enabled" value="false" />
-    <add key="SessionExpireTimeSpan" value="00:59:00" />
-    <add key="Content-Security-Policy" value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://www.google-analytics.com https://www.find-school-performance-data.service.gov.uk/; child-src 'none'; frame-src https://www.googletagmanager.com; img-src 'self' data: https://www.google-analytics.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://code.jquery.com http://d3js.org;" />
-    <add key="FinancialBenchmarkingCacheHours" value="72" />
-    <add key="FinancialBenchmarkingApiURL" value="https://aa-t1dv-sfb.azurewebsites.net/" />
-    <add key="FinancialBenchmarkingURL" value="https://as-t1dv-sfb.azurewebsites.net/" />
-    <add key="FinancialBenchmarkingUsername" value="" />
-    <add key="FinancialBenchmarkingPassword" value="" />
-    <add key="FscpdCacheHours" value="72" />
-    <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
-    <add key="FscpdURL" value="https://cscp-dev-web.azurewebsites.net/" />
-    <add key="FscpdUsername" value="" />
-    <add key="FscpdPassword" value="" />
+    <add key="OSPlacesApiKey" value="" />
+
+    <add key="ClientValidationEnabled" value="false" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="false" />
+
     <add key="SitemapCacheDays" value="21" />
     <add key="SitemapExcludeApi" value="0" />
+
+    <add key="Content-Security-Policy" value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://www.google-analytics.com https://www.find-school-performance-data.service.gov.uk/; child-src 'none'; frame-src https://www.googletagmanager.com; img-src 'self' data: https://www.google-analytics.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://code.jquery.com http://d3js.org;" />
+
+    <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/" />
+    <add key="CompaniesHouseApiKey" value="" />
+
+    <add key="FinancialBenchmarkingURL" value="https://as-t1dv-sfb.azurewebsites.net/" />
+    <add key="FinancialBenchmarkingApiURL" value="https://aa-t1dv-sfb.azurewebsites.net/" />
+    <add key="FinancialBenchmarkingCacheHours" value="72" />
+    <add key="FinancialBenchmarkingUsername" value="" />
+    <add key="FinancialBenchmarkingPassword" value="" />
+
+    <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
+    <add key="FscpdURL" value="https://cscp-dev-web.azurewebsites.net/" />
+    <add key="FscpdCacheHours" value="72" />
+    <add key="FscpdUsername" value="" />
+    <add key="FscpdPassword" value="" />
+
+
+
+    <add key="HttpAuthModuleEnabled" value="true" />
+    <add key="HttpAuthModule.AuthMode" value="Basic" />
+    <add key="HttpAuthModule.Realm" value="Edubase" />
+<!-- <add key="HttpAuthModule.Credentials" value="" /> -->
+    <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1" />
+
+    <!-- owin:appStartup: SASimulatorConfiguration || SecureAccessConfiguration -->
+    <add key="owin:appStartup" value="SASimulatorConfiguration" />
     <!--  STAGE config / DfE Signin; used by SecureAccessConfiguration-->
     <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase" />
     <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback" />
     <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata" />
     <!-- /SA STUFF -->
-    <!-- owin:appStartup: SASimulatorConfiguration || SecureAccessConfiguration -->
-    <add key="owin:appStartup" value="SASimulatorConfiguration" />
-    <add key="SASimulatorGuid" value="" />
+
+
+    <add key="SessionExpireTimeSpan" value="00:59:00" />
+
     <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/" />
+    <add key="SASimulatorGuid" value="" />
+
+
     <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
+
     <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />
     <add key="LookupApiUsername" value="" />
     <add key="LookupApiPassword" value="" />
-    <add key="DataQualityUpdatePeriod" value="7" />
+
     <add key="ApiTraceSessionRetentionCount" value="25" />
-    <add key="OSPlacesApiKey" value="" />
+
+    <add key="RouteDebugger:Enabled" value="false" />
     <add key="EnableApiLogging" value="false" />
   </appSettings>
   <!--<system.net>

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -9,26 +9,45 @@
 -->
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <!--
+      For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
+      or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you.
+    -->
     <section name="glimpse" type="Glimpse.Core.Configuration.Section, Glimpse.Core" />
+
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+
     <section name="httpAuthModule" type="System.Configuration.NameValueFileSectionHandler" />
   </configSections>
 
   <connectionStrings>
+    <!--
+        Connection string to the GIAS website's Azure Storage account
+        - Table storage
+        - Blob storage
+
+        Note that the API typically uses a different Azure Storage account
+        to serve e.g., pre-generated extracts/downloads.
+    -->
     <add name="DataConnectionString" connectionString="" />
+
+    <!--
+        The GIAS website makes (limited) use of Redis caches to minimise the number of API requests made.
+        This is in combination with a variety of in-memory caches.
+
+        GIAS's caching strategy is for review, and this may be removed at a later date.
+    -->
     <add name="Redis" connectionString="" />
   </connectionStrings>
-
   <appSettings>
+    <!-- ==== SERVER / WEBSITE CONFIGURATION ==== -->
+
     <!--
       The 'Environment` setting is used as a descriptor for the environment in which the application is running.
       - When running locally, this value should be set to 'localdev' (some local-specific options rely on this).
     -->
     <add key="Environment" value="localdev" />
-
-    <add key="DataQualityUpdatePeriod" value="7" />
 
     <add key="EnableErrorReporting" value="true" />
     <add key="EnableFriendlyErrorPage" value="true" />
@@ -36,6 +55,25 @@
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
 
+
+    <!-- ==== GIAS WEBSITE DEBUGGING ==== -->
+    <add key="ApiTraceSessionRetentionCount" value="25" />
+    <add key="RouteDebugger:Enabled" value="false" />
+    <add key="EnableApiLogging" value="false" />
+
+
+    <!-- ==== GIAS WEBSITE FUNCTIONALITY CONFIGURATION ==== -->
+    <add key="DataQualityUpdatePeriod" value="7" />
+
+    <add key="SitemapCacheDays" value="21" />
+    <add key="SitemapExcludeApi" value="0" />
+
+
+    <!-- ====  ==== -->
+    <add key="Content-Security-Policy" value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://www.google-analytics.com https://www.find-school-performance-data.service.gov.uk/; child-src 'none'; frame-src https://www.googletagmanager.com; img-src 'self' data: https://www.google-analytics.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://code.jquery.com http://d3js.org;" />
+
+
+    <!-- ==== JAVASCRIPT API KEYS ==== -->
     <add key="GoogleApiKeyClientSide" value="" />
     <add key="GoogleTagManagerKey" value="" />
     <add key="AzureMapsApiKey" value="" />
@@ -44,11 +82,18 @@
     <add key="ClientValidationEnabled" value="false" />
     <add key="UnobtrusiveJavaScriptEnabled" value="false" />
 
-    <add key="SitemapCacheDays" value="21" />
-    <add key="SitemapExcludeApi" value="0" />
 
-    <add key="Content-Security-Policy" value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://www.google-analytics.com https://www.find-school-performance-data.service.gov.uk/; child-src 'none'; frame-src https://www.googletagmanager.com; img-src 'self' data: https://www.google-analytics.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://code.jquery.com http://d3js.org;" />
+    <!-- ==== GIAS API DEPENDENCIES ==== -->
+    <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
+    <add key="api:Username" value="rest-api-user" />
+    <add key="api:Password" value="" />
 
+    <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />
+    <add key="LookupApiUsername" value="" />
+    <add key="LookupApiPassword" value="" />
+
+
+    <!-- ==== 3RD PARTY API DEPENDENCIES ==== -->
     <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/" />
     <add key="CompaniesHouseApiKey" value="" />
 
@@ -65,7 +110,7 @@
     <add key="FscpdPassword" value="" />
 
 
-
+    <!-- ==== WEBSITE AUTHENTICATION / AUTHORISATION ==== -->
     <add key="HttpAuthModuleEnabled" value="true" />
     <add key="HttpAuthModule.AuthMode" value="Basic" />
     <add key="HttpAuthModule.Realm" value="Edubase" />
@@ -78,28 +123,13 @@
     <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase" />
     <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback" />
     <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata" />
-    <!-- /SA STUFF -->
-
-
     <add key="SessionExpireTimeSpan" value="00:59:00" />
 
     <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/" />
     <add key="SASimulatorGuid" value="" />
 
-
-    <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
-    <add key="api:Username" value="rest-api-user" />
-    <add key="api:Password" value="" />
-
-    <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />
-    <add key="LookupApiUsername" value="" />
-    <add key="LookupApiPassword" value="" />
-
-    <add key="ApiTraceSessionRetentionCount" value="25" />
-
-    <add key="RouteDebugger:Enabled" value="false" />
-    <add key="EnableApiLogging" value="false" />
   </appSettings>
+
   <!--<system.net>
     <defaultProxy>
       <proxy bypassonlocal="False" usesystemdefault="True" proxyaddress="http://127.0.0.1:8888" />

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -581,8 +581,14 @@
     <add key="AuthMode" value="Digest" />
     <!-- [optional] default is "SecureZone" -->
     <add key="Realm" value="SecureZone" />
+
+    <!--
+      Caution - If these credentials are specified here but not explicitly overridden
+      (e.g., higher up in this page or within local settings/secrets), then these
+      defaults will be functional.
+    -->
     <!-- [required if http auth on] user1:pass1;user2:pass2;... -->
-    <add key="Credentials" value="hoge:hogepass;foo:foopass;" />
+    <!-- <add key="Credentials" value="hoge:hogepass;foo:foopass;" /> -->
     <!-- [optional] Digest Auth Nonce Valid Duration Minutes. default is 120 -->
     <add key="DigestNonceValidDuration" value="120" />
     <!-- [required if digest auth on] Digest Auth Nonce Salt -->


### PR DESCRIPTION
It's not perfect but this PR is progress toward adding documentation about each of the configuration options defined within `Web.config`.

Note that some defaults (e.g., URLs to non-production instances of 3rd party / other DfE APIs) has been removed from the `Web.config` file.

Developers relying on these defaults when running locally will need to add these values to `devsecrets.gias.config.alwaysignore` (i.e., if not already explicitly defining/overriding those values).