### PR TITLE
Bug fix, now applying the click handling per form and without incorrect/duplicated ID values.

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/Entry/independent-schools-predefinedsets.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/Entry/independent-schools-predefinedsets.js
@@ -1,23 +1,26 @@
 import GiasOkCancel from '../GiasModules/GiasModals/GiasOkCancel';
-  let dismissed = false;
-  const form = $('form');
-  form.on('submit', function (e) {
-    if (!dismissed) {
-      e.preventDefault();
-      $(this).okCancel({
-        ok: function () {
-          dismissed = true;
-          $(e.target).find("#delete").click();
-        },
-        immediate: true,
-        idPrefix: 'close-continue',
-        title: 'Are you sure you want to remove this set?',
-        content: 'You will no longer be able to filter by this set.'
-      });
-      $(this).removeData('okCancel');
-    }
-  });
 
+const formElements = $('form');
+
+// For each form element, add the confirmation behaviour to prompt if the user is sure about deleting an LA set.
+// Note that when JavaScript is disabled, currently the form will submit without confirmation.
+for (let i = 0; i < formElements.length; i++) {
+  const formElement = $(formElements[i]);
+  formElement.okCancel({
+    ok: function () {
+      // Disable the form submit handler, to allow the form to submit
+      formElement.off('submit');
+      formElement.submit();
+    },
+    immediate: false,
+    triggerEvent: 'submit',
+    title: 'Are you sure you want to remove this set?',
+    content: 'You will no longer be able to filter by this set.'
+  });
+}
+
+// When editing the LA set, options are displayed as pills and can individually be removed.
+// Note that this functionality requires JavaScript to function correctly.
 $('#la-id-target').on('click', '.remove-suggest-la', function (e) {
   e.preventDefault();
   $('#' + $(this).text().toLowerCase().replace(/\s/g, '-')).remove();

--- a/Web/Edubase.Web.UI/Views/Tools/PredefinedLASets.cshtml
+++ b/Web/Edubase.Web.UI/Views/Tools/PredefinedLASets.cshtml
@@ -61,11 +61,30 @@
                     <td data-label="Set name" class="govuk-table__cell">@Html.Field(item.Title)</td>
                     <td data-label="Local authorities" class="govuk-table__cell">@Html.Field(Model.GetLANames(item.Ids))</td>
                     <td nowrap="" class="govuk-table__cell">
-                        @using (Html.BeginRouteForm("DeletePredefinedLASet", new { id = item.RowKey }, FormMethod.Post))
+                        @using (Html.BeginRouteForm("DeletePredefinedLASet", new {id = item.RowKey}, FormMethod.Post))
                         {
-                            <a href="@Url.RouteUrl("IndSchSearch")?@QueryStringHelper.ToQueryString("d", item.Ids)&SelectedLocalAuthoritySetId=@item.RowKey" id="@StringUtils.ElementIdFormat(@Html.Field(item.Title))-select-link" class="action-link" aria-label="Select set">Select</a>
-                            @Html.RouteLink("Edit", "EditPredefinedLASet", new { id = item.RowKey }, new { @id = @StringUtils.ElementIdFormat(@Html.Field(item.Title)) + "-edit-link", @class = "action-link", @aria_link = "Edit set" })
-                            <button class="gias-link-button gias-link-button-s action-link" type="submit" id="@StringUtils.ElementIdFormat(@Html.Field(item.Title))-remove-link" aria-label="Remove set">Remove</button>
+                            <a
+                                href="@Url.RouteUrl("IndSchSearch")?@QueryStringHelper.ToQueryString("d", item.Ids)&SelectedLocalAuthoritySetId=@item.RowKey"
+                                id="@StringUtils.ElementIdFormat(@Html.Field(item.Title))-select-link"
+                                class="action-link"
+                                aria-label="Select set">
+                                Select
+                            </a>
+                            @Html.RouteLink("Edit",
+                                "EditPredefinedLASet",
+                                new {id = item.RowKey},
+                                new
+                                {
+                                    @id = @StringUtils.ElementIdFormat(@Html.Field(item.Title)) + "-edit-link",
+                                    @class = "action-link",
+                                    @aria_link = "Edit set"
+                                })
+                            <button
+                                class="gias-link-button gias-link-button-s action-link"
+                                type="submit" id="@StringUtils.ElementIdFormat(@Html.Field(item.Title))-remove-link"
+                                aria-label="Remove set">
+                                Remove
+                            </button>
                         }
                     </td>
                 </tr>


### PR DESCRIPTION
The implementation previously used a single global variable shared between all rows/forms on the page to conditionally make the ok/cancel modal dialog appear - this led to incorrect behaviour.

#140664