### PR TITLE
Add npm script `buildDevWatch` to have webpack watch for changes and automatically re-compile/rebuild

### DIFF
--- a/Web/Edubase.Web.UI/package.json
+++ b/Web/Edubase.Web.UI/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "stylelint": "stylelint \"./Assets/Sass/**/*.scss\" --config .stylelintrc --fix",
     "buildDev": "webpack --mode=development --progress=profile",
+    "buildDevWatch": "webpack --mode=development --progress=profile --watch",
     "build": "webpack --mode=production --progress",
     "buildCi": "webpack --mode=production --progress --env=ci"
   },


### PR DESCRIPTION
This change allows you to run `npm run-script buildDevWatch` 

This is identical to the pre-existing `npm run-script buildDev`, except it watches for any changes made to (e.g. JavaScript files) and automatically rebuilds without needing to manually re-run webpack.