### PR TITLE
show establishment type text in data owners table

### DIFF
--- a/Web/Edubase.Data/Entity/DataQualityStatus.cs
+++ b/Web/Edubase.Data/Entity/DataQualityStatus.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using Microsoft.WindowsAzure.Storage.Table;
 
@@ -24,7 +24,11 @@ namespace Edubase.Data.Entity
             IndependentSchools,
 
             [EnumMember(Value = "Pupil referral units")]
-            PupilReferralUnits
+            PupilReferralUnits,
+
+            [EnumMember(Value = "Secure academy 16-19 openers")]
+            AcademySecure16to19Openers
+
         }
 
         public DataQualityStatus()

--- a/Web/Edubase.Services/Security/EdubaseRoles.cs
+++ b/Web/Edubase.Services/Security/EdubaseRoles.cs
@@ -28,6 +28,7 @@ namespace Edubase.Services.Security
         public const string DUGE = "DUGE";
         public const string LSU = "LSU";
         public const string UKRLP = "UKRLP";
+        public const string YCS = "YCS";
         public const string SSAT = "SESAT";//this value was taken so we have used SESAT for secure single academy trust
     }
 }

--- a/Web/Edubase.Web.UI/Controllers/DataQualityController.cs
+++ b/Web/Edubase.Web.UI/Controllers/DataQualityController.cs
@@ -26,7 +26,8 @@ namespace Edubase.Web.UI.Controllers
             { EdubaseRoles.IEBT,  DataQualityStatus.DataQualityEstablishmentType.IndependentSchools},
             { EdubaseRoles.APT,  DataQualityStatus.DataQualityEstablishmentType.PupilReferralUnits},
             { EdubaseRoles.SOU,  DataQualityStatus.DataQualityEstablishmentType.LaMaintainedSchools},
-            { EdubaseRoles.FST,  DataQualityStatus.DataQualityEstablishmentType.FreeSchoolOpeners}
+            { EdubaseRoles.FST,  DataQualityStatus.DataQualityEstablishmentType.FreeSchoolOpeners},
+            { EdubaseRoles.YCS,  DataQualityStatus.DataQualityEstablishmentType.AcademySecure16to19Openers}
         };
 
         public DataQualityController(IDataQualityWriteService dataQualityWriteService)

--- a/Web/Edubase.Web.UIUnitTests/Controllers/DataQualityControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Controllers/DataQualityControllerTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+using Edubase.Data.Entity;
+using Edubase.Services.DataQuality;
+using Edubase.Web.UI.Controllers;
+using Edubase.Web.UI.Helpers;
+using Edubase.Web.UI.Models.DataQuality;
+using Moq;
+using Xunit;
+using static Edubase.Data.Entity.DataQualityStatus;
+
+namespace Edubase.Web.UIUnitTests.Controllers
+{
+    public class DataQualityControllerTests
+    {
+        private readonly Mock<IDataQualityWriteService> _writeServiceMock = new Mock<IDataQualityWriteService>();
+        private readonly Mock<IPrincipal> mockPrincipal = new Mock<IPrincipal>();
+        private readonly Mock<IIdentity> mockIdentity = new Mock<IIdentity>();
+        private readonly Mock<ControllerContext> mockControllerContext = new Mock<ControllerContext>();
+        private readonly Mock<HttpContextBase> mockHttpContextBase = new Mock<HttpContextBase>();
+        private readonly DataQualityController _controllerUnderTest;
+
+        public DataQualityControllerTests()
+        {
+            mockHttpContextBase.SetupGet(x => x.User)
+                .Returns(mockPrincipal.Object);
+            mockControllerContext.SetupGet(x => x.HttpContext)
+                .Returns(mockHttpContextBase.Object);
+            mockPrincipal.SetupGet(x => x.Identity)
+                .Returns(mockIdentity.Object);
+            _controllerUnderTest = new DataQualityController(_writeServiceMock.Object)
+            {
+                ControllerContext = mockControllerContext.Object
+            };
+        }
+
+        [Theory]
+        [InlineData((int) DataQualityEstablishmentType.AcademyOpeners)]
+        [InlineData((int) DataQualityEstablishmentType.FreeSchoolOpeners)]
+        [InlineData((int) DataQualityEstablishmentType.OpenAcademiesAndFreeSchools)]
+        [InlineData((int) DataQualityEstablishmentType.LaMaintainedSchools)]
+        [InlineData((int) DataQualityEstablishmentType.IndependentSchools)]
+        [InlineData((int) DataQualityEstablishmentType.PupilReferralUnits)]
+        [InlineData((int) DataQualityEstablishmentType.AcademySecure16to19Openers)]
+        public async Task ViewStatus_ReturnsPopulatedViewItems(int establishmentType)
+        {
+            var dataQualityStatus = new DataQualityStatus()
+            {
+                EstablishmentType = (DataQualityEstablishmentType) establishmentType,
+                DataOwner = "Test data owner",
+                Email = "Test email"                
+            };
+            _writeServiceMock.Setup(x => x.GetDataQualityStatus())
+                .ReturnsAsync(new List<DataQualityStatus>() { dataQualityStatus });
+
+            var result = await _controllerUnderTest.ViewStatus(false);
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var viewmodel = Assert.IsType<FullDataQualityStatusViewModel>(viewResult.Model);
+            var dataQualityStatusItemReturned = Assert.Single(viewmodel.Items);
+            Assert.Equal(dataQualityStatus.EstablishmentType, dataQualityStatusItemReturned.EstablishmentType);
+            Assert.Equal(dataQualityStatus.DataOwner, dataQualityStatusItemReturned.DataOwner);
+            Assert.Equal(dataQualityStatus.Email, dataQualityStatusItemReturned.Email);
+        }
+    }
+}


### PR DESCRIPTION
the tools->View data owner teams' data status screen
has had the following entry added:

Establishment type: Secure academy 16-19 openers
Last updated:
Data owner: Youth Custody Service
Email: [SecureSchools.operations@justice.gov.uk](mailto:SecureSchools.operations@justice.gov.uk)

minimal code changes needed to display the establishment type string
[Devops story #146386](https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/146386)