### PR TITLE
added YCS as a role requiring data owner popup

### DIFF
--- a/Web/Edubase.Web.UI/Controllers/Api/UserRolesController.cs
+++ b/Web/Edubase.Web.UI/Controllers/Api/UserRolesController.cs
@@ -1,4 +1,4 @@
-﻿using Edubase.Services.Security;
+using Edubase.Services.Security;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +20,8 @@ namespace Edubase.Web.UI.Controllers.Api
                         EdubaseRoles.IEBT,      // Independent schools
                         EdubaseRoles.APT,       // Alt provision team
                         EdubaseRoles.SOU,       // SOPT
-                        EdubaseRoles.FST        // Free school openers
+                        EdubaseRoles.FST,       // Free school openers
+                        EdubaseRoles.YCS        // Youth custody service
                     );
     }
 }


### PR DESCRIPTION
YCS is a new user role - they are the data owner for secure 16-19 academies and therefore I've added them to the list of roles in UserRequiresDataQualityPrompt https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/149237
