### PR TITLE
16 19 secure/144281 governance and legal duties

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -889,7 +889,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 await _cachedLookupService.GovernorAppointingBodiesGetAllAsync(),
                 governorPermissions);
 
-            if (establishmentUrn.HasValue || establishmentModel != null)
+            if (establishmentUrn.HasValue || establishmentModel != null) // governance view for an establishment
             {
                 var estabDomainModel = establishmentModel ??
                                        (await _establishmentReadService.GetAsync(establishmentUrn.Value, user))
@@ -899,13 +899,14 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 viewModel.GovernanceMode = items.Any() ? estabDomainModel.GovernanceMode : null;
             }
 
-            if (groupUId.HasValue)
+            if (groupUId.HasValue) // governance view for a group
             {
                 var groupModel = (await _groupReadService.GetAsync(groupUId.Value, user)).GetResult();
                 viewModel.ShowDelegationAndCorpContactInformation =
                     groupModel.GroupTypeId == (int) eLookupGroupType.MultiacademyTrust;
                 viewModel.DelegationInformation = groupModel.DelegationInformation;
                 viewModel.CorporateContact = groupModel.CorporateContact;
+                viewModel.GroupTypeId = groupModel.GroupTypeId;
             }
 
             return viewModel;

--- a/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
@@ -176,38 +176,16 @@ else
 
 @helper ShowLegalDuty()
 {
-    <div class="governors-section">
-        <h2 class="govuk-heading-s">Legal duty to provide governance information</h2>
-        <details class="govuk-details govuk-!-font-size-16" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                    More details
-                </span>
-            </summary>
-            <div class="govuk-details__text">
-                <p class="govuk-!-font-size-16">
-                    All maintained school governing bodies and academy trusts have a legal duty to provide all of the governance information requested on this page in so far as it is available to them.
-                </p>
-                <p class="govuk-!-font-size-16">
-                    This will increase the transparency of governance arrangements. It will enable schools and the department to identify more quickly and accurately individuals who are involved in governance, and who govern in more than one context.
-                </p>
-                <p class="govuk-!-font-size-16">
-                    The information requested says nothing in itself about a person's suitability to govern. However, it is essential information for the department to be able to uniquely identify an individual and in a small number of cases conduct checks to confirm their suitability for this important and influential role.
-                </p>
-                <p class="govuk-!-font-size-16">
-                    You should provide all of the information requested insofar as it is available to you. A minimum set of information needs to be provided before a record can be saved.
-                </p>
-                <p class="govuk-!-font-size-16">
-                    A suggested privacy notice for schools is available for download:
-                    <a target="_blank" rel="noreferrer noopener" href="https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices">
-                        https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices (opens in new tab)
-                    </a>
-                </p>
-            </div>
-        </details>
-    </div>
+    if (Model.GroupTypeId == (int) eLookupGroupType.SecureSingleAcademyTrust)
+    {
+        // viewing the governance tab for a secure single-academy trust
+        Html.RenderPartial("_LegalDutySecureAcademyTrustStatement");
+    }
+    else
+    {
+        Html.RenderPartial("_LegalDutyStatement");
+    }
 }
-
 
 
 @helper DisplayGovernors()

--- a/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/_LegalDutySecureAcademyTrustStatement.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/_LegalDutySecureAcademyTrustStatement.cshtml
@@ -1,0 +1,32 @@
+<div class="governors-section">
+    <h2 class="govuk-heading-s">Legal duty to provide governance information</h2>
+    <details class="govuk-details govuk-!-font-size-16" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                More details
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-!-font-size-16">
+                Secure single-academy trusts (SSATs) must keep their governance information up to date on Get Information about Schools (GIAS) as referenced in the secure school governance handbook.
+            </p>
+            <p class="govuk-!-font-size-16">
+                This will increase the transparency of governance arrangements. It will enable academy trusts, schools and the department to identify more quickly and accurately individuals who are involved in governance, and who govern in more than one context.
+            </p>
+            <p class="govuk-!-font-size-16">
+                The information requested says nothing in itself about a person's suitability to govern. However, it is essential information for the department to be able to uniquely identify an individual and in a small number of cases conduct checks to confirm their suitability for this important and influential role.
+            </p>
+            <p class="govuk-!-font-size-16">
+                You should provide all of the information requested insofar as it is available to you. A minimum set of information needs to be provided before a record can be saved.
+            </p>
+            <p class="govuk-!-font-size-16">
+                A suggested privacy notice for the secure single-academy trust (SSAT) is available for download:
+                <a target="_blank" rel="noreferrer noopener" href="https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices">
+                    https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices (opens in new tab)
+                </a>
+            </p>
+        </div>
+    </details>
+</div>
+
+

--- a/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/_LegalDutyStatement.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/_LegalDutyStatement.cshtml
@@ -1,0 +1,31 @@
+<div class="governors-section">
+    <h2 class="govuk-heading-s">Legal duty to provide governance information</h2>
+    <details class="govuk-details govuk-!-font-size-16" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+                More details
+            </span>
+        </summary>
+        <div class="govuk-details__text">
+            <p class="govuk-!-font-size-16">
+                All maintained school governing bodies and academy trusts have a legal duty to provide all of the governance information requested on this page in so far as it is available to them.
+            </p>
+            <p class="govuk-!-font-size-16">
+                This will increase the transparency of governance arrangements. It will enable schools and the department to identify more quickly and accurately individuals who are involved in governance, and who govern in more than one context.
+            </p>
+            <p class="govuk-!-font-size-16">
+                The information requested says nothing in itself about a person's suitability to govern. However, it is essential information for the department to be able to uniquely identify an individual and in a small number of cases conduct checks to confirm their suitability for this important and influential role.
+            </p>
+            <p class="govuk-!-font-size-16">
+                You should provide all of the information requested insofar as it is available to you. A minimum set of information needs to be provided before a record can be saved.
+            </p>
+            <p class="govuk-!-font-size-16">
+                A suggested privacy notice for schools is available for download:
+                <a target="_blank" rel="noreferrer noopener" href="https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices">
+                    https://www.gov.uk/government/publications/data-protection-and-privacy-privacy-notices (opens in new tab)
+                </a>
+            </p>
+        </div>
+    </details>
+</div>
+

--- a/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
+++ b/Web/Edubase.Web.UI/Edubase.Web.UI.csproj
@@ -890,6 +890,8 @@
     <Content Include="Views\News\EditArticle.cshtml" />
     <Content Include="Views\News\AuditArticles.cshtml" />
     <Content Include="Views\News\AuditArticle.cshtml" />
+    <Content Include="Areas\Governors\Views\Governor\_LegalDutySecureAcademyTrustStatement.cshtml" />
+    <Content Include="Areas\Governors\Views\Governor\_LegalDutyStatement.cshtml" />
     <None Include="packages.config" />
     <Content Include="Views\Guidance\LaNameCodes.cshtml" />
     <Content Include="Views\Guidance\SelectFormat.cshtml" />

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -437,8 +437,10 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             Assert.Equal(model, modelResult);
         }
 
-        [Fact()]
-        public void Gov_View_groupUIdSpecified()
+        [Theory]
+        [InlineData((int) eLookupGroupType.MultiacademyTrust, true)]
+        [InlineData((int) eLookupGroupType.SecureSingleAcademyTrust, false)]
+        public void Gov_View_groupUIdSpecified(int groupTypeId, bool expectedShowDelegationAndCorpContactInformation)
         {
             var groupUId = 10;
             var governorDetailsDto = new GovernorsDetailsDto
@@ -453,7 +455,11 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 HistoricalGovernors = new List<GovernorModel>()
             };
 
-            var groupModel = new GroupModel { DelegationInformation = "delegation info" };
+            var groupModel = new GroupModel {
+                DelegationInformation = "delegation info",
+                CorporateContact = "corporate contact info",
+                GroupTypeId = groupTypeId
+            };
 
             mockGovernorsReadService.Setup(g => g.GetGovernorListAsync(null, groupUId, It.IsAny<IPrincipal>()))
                 .ReturnsAsync(() => governorDetailsDto);
@@ -469,9 +475,11 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             Assert.NotNull(viewResult);
             Assert.Equal("~/Areas/Governors/Views/Governor/ViewEdit.cshtml", viewResult.ViewName);
             Assert.NotNull(modelResult);
-            Assert.False(modelResult.ShowDelegationAndCorpContactInformation);
+            Assert.Equal(expectedShowDelegationAndCorpContactInformation, modelResult.ShowDelegationAndCorpContactInformation);
             Assert.Equal(groupModel.DelegationInformation, modelResult.DelegationInformation);
             Assert.Equal(groupUId, modelResult.GroupUId);
+            Assert.Equal(groupModel.GroupTypeId, modelResult.GroupTypeId);
+            Assert.Equal(groupModel.CorporateContact, modelResult.CorporateContact);
             Assert.Null(modelResult.EstablishmentUrn);
         }
 


### PR DESCRIPTION
[16-19 Secure academies - Governance and Legal duty](https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_boards/board/t/Get%20Information%20About%20Schools/Stories/?workitem=144281)

Added a different statement for Secure SAT
Secure 16-19 establishments don't have a governance tab so this statement only shows for the trust (the SSAT group), not the establishment (in case you were wondering)