### PR TITLE
change config for lookups API

### DIFF
--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -165,8 +165,8 @@
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
 
-    <add key="LookupApiBaseAddress" value="https://s158d01-func-dd-restapi.azurewebsites.net/api/" />
-    <add key="LookupApiUsername" value="" />
+    <add key="LookupApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
+    <add key="LookupApiUsername" value="rest-api-user" />
     <add key="LookupApiPassword" value="" />
 
 

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -161,11 +161,11 @@
       Note: Do not supply username/password (or other secrets) directly here.
       Specify this via app config on Azure, or via dev secrets if running locally.
     -->
-    <add key="TexunaApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
+    <add key="TexunaApiBaseAddress" value="" />
     <add key="api:Username" value="rest-api-user" />
     <add key="api:Password" value="" />
 
-    <add key="LookupApiBaseAddress" value="https://app-api-t1dv-edubase.azurewebsites.net/edubase/rest/" />
+    <add key="LookupApiBaseAddress" value="" />
     <add key="LookupApiUsername" value="rest-api-user" />
     <add key="LookupApiPassword" value="" />
 


### PR DESCRIPTION
**I've made modifications to this since getting approvals so I tried to reset the approvals but failed!**

Move back to getting lookups from the java API rather than the c# replacement API. The c# replacement API has not been released to production and we are adding functionality to the java lookups API for 16-19, hence going back to using that API for lookups.

This change is related to previous PRs https://github.com/DFE-Digital/get-information-about-schools/pull/237 and https://github.com/DFE-Digital/get-information-about-schools/pull/340 where the lookups API config was split out from the texuna API config to allow different APIs for each and the lookups API was pointed to the new c# replacement API
