### PR TITLE
add YCS to list of AuthorisationRoles

### DIFF
--- a/Web/Edubase.Web.UI/Controllers/DataQualityController.cs
+++ b/Web/Edubase.Web.UI/Controllers/DataQualityController.cs
@@ -32,7 +32,7 @@ namespace Edubase.Web.UI.Controllers
             { EdubaseRoles.YCS,  DataQualityStatus.DataQualityEstablishmentType.AcademySecure16to19Openers}
         };
 
-        private const string AuthorisationRoles = AuthorizedRoles.IsAdmin + "," + EdubaseRoles.EFADO + "," + EdubaseRoles.AP_AOS + "," + EdubaseRoles.IEBT + "," + EdubaseRoles.APT + "," + EdubaseRoles.SOU + "," + EdubaseRoles.FST;
+        private const string AuthorisationRoles = AuthorizedRoles.IsAdmin + "," + EdubaseRoles.EFADO + "," + EdubaseRoles.AP_AOS + "," + EdubaseRoles.IEBT + "," + EdubaseRoles.APT + "," + EdubaseRoles.SOU + "," + EdubaseRoles.FST + "," + EdubaseRoles.YCS;
 
         public DataQualityController(IDataQualityWriteService dataQualityWriteService)
         {

--- a/Web/Edubase.Web.UI/Views/DataQuality/ViewStatus.cshtml
+++ b/Web/Edubase.Web.UI/Views/DataQuality/ViewStatus.cshtml
@@ -71,7 +71,7 @@
             <div class="button-row govuk-!-padding-top-4">
                 @if (Model.UserCanUpdateLastUpdated)
                 {
-                    @Html.ActionLink("Update last updated dates", "EditStatus", "DataQuality", new {area = ""}, new {@class = "govuk-button govuk-button--secondary", data_module = "govuk-button"})
+                    @Html.ActionLink("Update last updated dates", "EditStatus", "DataQuality", new {area = ""}, new {@class = "govuk-button govuk-button--secondary", data_module = "govuk-button", id="last-updated-date-button"})
                 }
                 @if (Model.UserCanUpdateDataOwnerDetails)
                 {


### PR DESCRIPTION
Fix to allow YCS users to update their last updated date as the data owner for secure academies

https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/148501