### PR TITLE
content changes to show that SSATs appear in the trusts closure report

### DIFF
--- a/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/DownloadsController.cs
@@ -279,12 +279,12 @@ namespace Edubase.Web.UI.Controllers
 
         [HttpGet, EdubaseAuthorize, MvcAuthorizeRoles(AuthorizedRoles.CanManageAcademyTrusts)]
         [Route("Download/MATClosureReport", Name = "DownloadMATClosureReport")]
-        public async Task<ActionResult> DownloadMATClosureReportAsync()
+        public async Task<ActionResult> DownloadMATClosureReportAsync(string filename)
         {
             using (var c = IocConfig.CreateHttpClient())
             {
                 var requestMessage = await _httpClientHelper.CreateHttpRequestMessageAsync(HttpMethod.Get, "downloads/matclosurereport.csv", User);
-                var response = (await c.SendAsync(requestMessage));
+                var response = await c.SendAsync(requestMessage);
 
                 if(response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
@@ -293,7 +293,7 @@ namespace Edubase.Web.UI.Controllers
                 else
                 {
                     response.EnsureSuccessStatusCode();
-                    return new FileStreamResult(await response.Content.ReadAsStreamAsync(), response.Content.Headers.ContentType.MediaType) { FileDownloadName = $"SatAndMatClosureReport_{DateTime.Now.Date.ToString("dd-MM-yyyy")}.csv" };
+                    return new FileStreamResult(await response.Content.ReadAsStreamAsync(), response.Content.Headers.ContentType.MediaType) { FileDownloadName = filename };
                 }
             }
         }

--- a/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
@@ -237,10 +237,10 @@ namespace Edubase.Web.UI.Models
                 retVal.Add(new LinkAction
                 {
                     Link = htmlHelper.RouteLink(
-                        "View closed Companies House single-academy trusts (SATs) and multi-academy trusts (MATs)",
+                        "View closed Companies House single-academy trusts (SATs), secure single-academy trusts (SSATs) and multi-academy trusts (MATs)",
                         "DownloadClosedTrustsInformation"),
                     Description =
-                        "View a list of closed single-academy trusts (SATs) and multi-academy trusts (MATs) currently open on GIAS but reported closed by Companies House."
+                        "View a list of closed single-academy trusts (SATs), secure single-academy trusts (SSATs) and multi-academy trusts (MATs) currently open on GIAS but reported closed by Companies House."
                 });
             }
 

--- a/Web/Edubase.Web.UI/Views/Tools/DownloadClosedTrustsInformation.cshtml
+++ b/Web/Edubase.Web.UI/Views/Tools/DownloadClosedTrustsInformation.cshtml
@@ -1,6 +1,6 @@
 @{
     ViewBag.SiteSection = "tools";
-    var fileName = $"SatAndMatClosureReport_{DateTime.Now.Date.ToString("dd-MM-yyyy")}.csv";
+    var fileName = $"SsatSatAndMatClosureReport_{DateTime.Now.Date.ToString("dd-MM-yyyy")}.csv";
 }
 @section BreadCrumbs {
    <div class="govuk-grid-row">
@@ -20,18 +20,18 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl">Closed single-academy trusts
-            (SATs) and multi-academy trusts (MATs)</h1>
+            (SATs), secure single-academy trusts (SSATs) and multi-academy trusts (MATs)</h1>
     </div>
 </div>
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
         <p>
-            Download the following file to view a list of closed single-academy trusts and multi-academy trusts.
+            Download the following file to view a list of closed single-academy trusts, secure single-academy trusts and multi-academy trusts.
             These are currently open on GIAS but reported closed by Companies House.
         </p>
         <p>
-            @Html.RouteLink(fileName, "DownloadMatClosureReport")
+            @Html.RouteLink(fileName, "DownloadMatClosureReport", new { filename = fileName })
         </p>
     </div>
 </div>


### PR DESCRIPTION
FE work - text changes to show that the report now includes secure 16-19 academy trusts
https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/146409
