### PR TITLE
new lookup service for lookups based on user

### DIFF
--- a/Web/Edubase.Services.Texuna/Lookup/LookupApiService.cs
+++ b/Web/Edubase.Services.Texuna/Lookup/LookupApiService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using Edubase.Services.Domain;
 using Edubase.Services.Lookup;
@@ -7,7 +8,7 @@ using Edubase.Services.Security;
 
 namespace Edubase.Services.Texuna.Lookup
 {
-    public class LookupApiService : ILookupService
+    public class LookupApiService : ILookupService, IUserDependentLookupService
     {
         private const string ApiPrefix = "lookup/";
         private readonly IHttpClientWrapper _httpClient;
@@ -384,6 +385,11 @@ namespace Edubase.Services.Texuna.Lookup
         public async Task<IEnumerable<LookupDto>> CASWardsGetAllAsync()
         {
             return await GetData("cas-wards");
+        }
+
+        public async Task<IEnumerable<LookupDto>> EstablishmentStatusesGetAllAsync(IPrincipal user)
+        {
+            return (await _httpClient.GetAsync<List<LookupDto>>(ApiPrefix + "establishment-statuses", user)).GetResponse();
         }
 
         private async Task<IEnumerable<LookupDto>> GetData(string name)

--- a/Web/Edubase.Services.TexunaUnitTests/Lookup/LookupApiServiceTests.cs
+++ b/Web/Edubase.Services.TexunaUnitTests/Lookup/LookupApiServiceTests.cs
@@ -50,7 +50,8 @@ namespace Edubase.Services.Texuna.Lookup.Tests
         public async Task AsyncLookupsTest(string lookupType)
         {
             //use reflection to construct method name
-            var method = _lookupApiService.GetType().GetMethod($"{lookupType}GetAllAsync");
+            var method = _lookupApiService.GetType().GetMethod($"{lookupType}GetAllAsync",
+                Type.EmptyTypes);
             var taskResult = method.Invoke(_lookupApiService, null) as Task<IEnumerable<LookupDto>>;
             var result = await taskResult;
 

--- a/Web/Edubase.Services/Edubase.Services.csproj
+++ b/Web/Edubase.Services/Edubase.Services.csproj
@@ -294,6 +294,7 @@
     <Compile Include="IntegrationEndPoints\Smtp\SmtpEndPoint.cs" />
     <Compile Include="Lookup\ICachedLookupService.cs" />
     <Compile Include="Lookup\ILookupService.cs" />
+    <Compile Include="Lookup\IUserDependentLookupService.cs" />
     <Compile Include="Nomenclature\NomenclatureService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Security\ClaimsIdentityConverters\StubClaimsIdConverter.cs" />

--- a/Web/Edubase.Services/Lookup/IUserDependentLookupService.cs
+++ b/Web/Edubase.Services/Lookup/IUserDependentLookupService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+using Edubase.Services.Domain;
+
+namespace Edubase.Services.Lookup
+{
+    public interface IUserDependentLookupService
+    {
+        Task<IEnumerable<LookupDto>> EstablishmentStatusesGetAllAsync(IPrincipal user);
+    }
+}

--- a/Web/Edubase.Web.UI/App_Start/IocConfig.cs
+++ b/Web/Edubase.Web.UI/App_Start/IocConfig.cs
@@ -164,7 +164,8 @@ namespace Edubase.Web.UI
             builder.Register(c => new LookupApiService(
                     c.ResolveNamed<HttpClientWrapper>("LookupHttpClientWrapper"),
                     c.Resolve<ISecurityService>()))
-                .As<ILookupService>();
+                .As<ILookupService>()
+                .As<IUserDependentLookupService>();
 
             builder.RegisterType<GovernorDownloadApiService>().As<IGovernorDownloadService>();
             builder.RegisterType<GovernorsReadApiService>().As<IGovernorsReadService>();

--- a/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
@@ -51,6 +51,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
         private readonly IMapper _mapper;
         private readonly IResourcesHelper _resourcesHelper;
         private readonly IExternalLookupService _externalLookupService;
+        private readonly IUserDependentLookupService _lookupService;
 
         private readonly ISecurityService _securityService;
         private readonly Lazy<string[]> _formKeys;
@@ -80,7 +81,8 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
             ICachedLookupService cachedLookupService,
             IResourcesHelper resourcesHelper,
             ISecurityService securityService,
-            IExternalLookupService externalLookupService)
+            IExternalLookupService externalLookupService,
+            IUserDependentLookupService lookupService)
         {
             _cachedLookupService = cachedLookupService;
             _establishmentReadService = establishmentReadService;
@@ -90,6 +92,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
             _resourcesHelper = resourcesHelper;
             _securityService = securityService;
             _externalLookupService = externalLookupService;
+            _lookupService = lookupService;
 
             _formKeys = new Lazy<string[]>(
                 () => Request?.Form?.AllKeys.Select(x => x.GetPart(".")).Distinct().ToArray(),
@@ -885,7 +888,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
             viewModel.GovernanceOptions = (await _cachedLookupService.CCGovernanceGetAllAsync()).ToSelectList();
             viewModel.DisadvantagedAreaOptions = (await _cachedLookupService.CCDisadvantagedAreasGetAllAsync()).ToSelectList();
             viewModel.DirectProvisionOfEarlyYearsOptions = (await _cachedLookupService.DirectProvisionOfEarlyYearsGetAllAsync()).ToSelectList();
-            viewModel.EstablishmentStatusOptions = (await _cachedLookupService.EstablishmentStatusesGetAllAsync()).ToSelectList();
+            viewModel.EstablishmentStatusOptions = (await _lookupService.EstablishmentStatusesGetAllAsync(User)).ToSelectList();
             viewModel.Address.Counties = (await _cachedLookupService.CountiesGetAllAsync()).ToSelectList();
             viewModel.Phases = (await _cachedLookupService.CCPhaseTypesGetAllAsync()).ToSelectList();
             await PopulateSelectLists(viewModel);
@@ -1051,7 +1054,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
             viewModel.LocalAuthorities = localAuthorities.ToSelectList(viewModel.LocalAuthorityId);
             viewModel.EstablishmentTypes = (await _cachedLookupService.EstablishmentTypesGetAllAsync()).ToSelectList(viewModel.TypeId);
             viewModel.HeadTitles = (await _cachedLookupService.TitlesGetAllAsync()).ToSelectList(viewModel.HeadTitleId);
-            viewModel.Statuses = (await _cachedLookupService.EstablishmentStatusesGetAllAsync()).ToSelectList(viewModel.StatusId);
+            viewModel.Statuses = (await _lookupService.EstablishmentStatusesGetAllAsync(User)).ToSelectList(viewModel.StatusId);
             viewModel.AdmissionsPolicies = (await _cachedLookupService.AdmissionsPoliciesGetAllAsync()).ToSelectList(viewModel.AdmissionsPolicyId);
             viewModel.Inspectorates = (await _cachedLookupService.InspectoratesGetAllAsync()).ToSelectList(viewModel.InspectorateId);
             viewModel.IndependentSchoolTypes = (await _cachedLookupService.IndependentSchoolTypesGetAllAsync()).ToSelectList(viewModel.IndependentSchoolTypeId);

--- a/Web/Edubase.Web.UIUnitTests/Areas/Establishments/Controllers/EstablishmentControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Establishments/Controllers/EstablishmentControllerTests.cs
@@ -31,7 +31,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers.UnitTests
     {
         private readonly EstablishmentController controller;
         private readonly Mock<ICachedLookupService> mockCachedLookupService;
-
+        private readonly Mock<IUserDependentLookupService> mockLookupService;
         private readonly Mock<IEstablishmentReadService> mockEstablishmentReadService = new Mock<IEstablishmentReadService>(MockBehavior.Strict);
         private readonly Mock<IGroupReadService> mockGroupReadService = new Mock<IGroupReadService>(MockBehavior.Strict);
         private readonly Mock<IMapper> mockMapper = new Mock<IMapper>(MockBehavior.Strict);
@@ -54,6 +54,8 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers.UnitTests
         {
             mockCachedLookupService = MockHelper.SetupCachedLookupService();
 
+            mockLookupService = MockHelper.SetupLookupService(mockPrincipal.Object);
+
             mockEstablishmentReadService.Setup(e => e.GetEstabType2EducationPhaseMap())
                .Returns(new Dictionary<eLookupEstablishmentType, eLookupEducationPhase[]>());
 
@@ -68,8 +70,8 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers.UnitTests
                 mockCachedLookupService.Object,
                 mockResourcesHelper.Object,
                 mockSecurityService.Object,
-                mockExternalLookupService.Object);
-
+                mockExternalLookupService.Object,
+                mockLookupService.Object);
 
             SetupController();
         }

--- a/Web/Edubase.Web.UIUnitTests/MockHelper.cs
+++ b/Web/Edubase.Web.UIUnitTests/MockHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Security.Principal;
 using Edubase.Services.Domain;
 using Edubase.Services.Lookup;
 using Moq;
@@ -69,6 +70,14 @@ namespace Edubase.Web.UIUnitTests
             cls.Setup(c => c.DirectProvisionOfEarlyYearsGetAllAsync()).ReturnsAsync(() => new List<LookupDto> { new LookupDto() });
 
             return cls;
+        }
+
+        public static Mock<IUserDependentLookupService> SetupLookupService(IPrincipal user)
+        {
+            var ls = new Mock<IUserDependentLookupService>(MockBehavior.Strict);
+            ls.Setup(c => c.EstablishmentStatusesGetAllAsync(user)).ReturnsAsync(() => new List<LookupDto> { new LookupDto() });
+
+            return ls;
         }
     }
 }


### PR DESCRIPTION
The API lookup service has been modified to return values for the establishment status dropdown dependent on the user.
Changes to FE code to use the lookup directly, avoiding the caching, because the caching doesn't cache by user (now I'm writing this though I wonder if I could have implemented caching per user)