### PR TITLE
16 19 secure/145544 governance view

### DIFF
--- a/Web/Edubase.Services/Edubase.Services.csproj
+++ b/Web/Edubase.Services/Edubase.Services.csproj
@@ -216,6 +216,7 @@
     <Compile Include="Geo\PlacesLookupService.cs" />
     <Compile Include="Governors\DisplayPolicies\GovernorDisplayPolicy.cs" />
     <Compile Include="Governors\Downloads\GovernorSearchDownloadPayload.cs" />
+    <Compile Include="Governors\Factories\GovernorRoleNameFactory.cs" />
     <Compile Include="Governors\IGovernorsWriteService.cs" />
     <Compile Include="Governors\Models\GovernorAppointment.cs" />
     <Compile Include="Governors\Models\GovernorBulkUpdateValidationResult.cs" />

--- a/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
+++ b/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
@@ -18,6 +18,6 @@ namespace Edubase.Services.Enums
         Group_SharedLocalGovernor = 12,
         Establishment_SharedLocalGovernor = 13,
         Member_Individual = 21,
-        Member_Organisation = 22,
+        Member_Organisational = 22,
     }
 }

--- a/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
+++ b/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
@@ -18,6 +18,6 @@ namespace Edubase.Services.Enums
         Group_SharedLocalGovernor = 12,
         Establishment_SharedLocalGovernor = 13,
         Member_Individual = 21,
-        Member_Organisational = 22,
+        Member_Organisation = 22,
     }
 }

--- a/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
+++ b/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
@@ -17,5 +17,7 @@ namespace Edubase.Services.Enums
         Establishment_SharedChairOfLocalGoverningBody = 11,
         Group_SharedLocalGovernor = 12,
         Establishment_SharedLocalGovernor = 13,
+        Member_Individual = 21,
+        Member_Organisation = 22,
     }
 }

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -21,7 +21,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor" },
             { eLookupGovernorRole.Member, "Member" },
             { eLookupGovernorRole.Member_Individual, "Member - individual" },
-            { eLookupGovernorRole.Member_Organisation, "Member - organisational" },
+            { eLookupGovernorRole.Member_Organisational, "Member - organisational" },
             { eLookupGovernorRole.Trustee, "Trustee" },
             {eLookupGovernorRole.NA, "N a" }
         };
@@ -34,7 +34,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors" },
             { eLookupGovernorRole.Member, "Members" },
             { eLookupGovernorRole.Member_Individual, "Members - individual" },
-            { eLookupGovernorRole.Member_Organisation, "Members - organisational" },
+            { eLookupGovernorRole.Member_Organisational, "Members - organisational" },
             { eLookupGovernorRole.Trustee, "Trustees" }
         };
 

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -1,18 +1,11 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Edubase.Common.Text;
 using Edubase.Services.Enums;
-using Humanizer;
 
 namespace Edubase.Services.Governors.Factories
 {
-    public class GovernorRoleNameFactory
+    public static class GovernorRoleNameFactory
     {
-        private readonly bool _usePluralisedName;
-
         private static readonly Dictionary<eLookupGovernorRole, string> SentenceCaseLabels = new Dictionary<eLookupGovernorRole, string>()
         {
             { eLookupGovernorRole.Governor, "Governor" },
@@ -45,17 +38,12 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Trustee, "Trustees" }
         };
 
-        public GovernorRoleNameFactory(bool pluralisedName)
+        public static string Create(eLookupGovernorRole role, eTextCase textCase = eTextCase.SentenceCase, bool pluraliseLabelIfApplicable = false)
         {
-            _usePluralisedName = pluralisedName;
-        }
-
-        public string Create(eLookupGovernorRole role, eTextCase textCase = eTextCase.SentenceCase)
-        {
-            var temp = _usePluralisedName ?
+            var governorlabel = pluraliseLabelIfApplicable ?
                 PluralisedLabels.ContainsKey(role) ? PluralisedLabels[role] : SentenceCaseLabels[role]
                 : SentenceCaseLabels[role];
-            return textCase == eTextCase.SentenceCase ? temp : temp.ToLower();
+            return textCase == eTextCase.SentenceCase ? governorlabel : governorlabel.ToLower();
         }
     }
 }

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Edubase.Common.Text;
+using Edubase.Services.Enums;
+using Humanizer;
+
+namespace Edubase.Services.Governors.Factories
+{
+    public class GovernorRoleNameFactory
+    {
+        private readonly bool _usePluralisedName;
+
+        private static readonly Dictionary<eLookupGovernorRole, string> SentenceCaseLabels = new Dictionary<eLookupGovernorRole, string>()
+        {
+            { eLookupGovernorRole.Governor, "Governor" },
+            { eLookupGovernorRole.LocalGovernor, "Local governor" },
+            { eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governor" },
+            { eLookupGovernorRole.ChairOfLocalGoverningBody, "Chair of local governing body" },
+            { eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "Shared chair of local governing body" },
+            { eLookupGovernorRole.AccountingOfficer, "Accounting officer" },
+            { eLookupGovernorRole.ChairOfGovernors, "Chair of governors" },
+            { eLookupGovernorRole.ChairOfTrustees, "Chair of trustees" },
+            { eLookupGovernorRole.ChiefFinancialOfficer, "Chief financial officer" },
+            { eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "Shared chair of local governing body" },
+            { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor" },
+            { eLookupGovernorRole.Member, "Member" },
+            { eLookupGovernorRole.Member_Individual, "Member - individual" },
+            { eLookupGovernorRole.Member_Organisation, "Member - organisation" },
+            { eLookupGovernorRole.Trustee, "Trustee" },
+            {eLookupGovernorRole.NA, "N a" }
+        };
+
+        private static readonly Dictionary<eLookupGovernorRole, string> PluralisedLabels = new Dictionary<eLookupGovernorRole, string>()
+        {
+            { eLookupGovernorRole.Governor, "Governors" },
+            { eLookupGovernorRole.LocalGovernor, "Local governors" },
+            { eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governors" },
+            { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors" },
+            { eLookupGovernorRole.Member, "Members" },
+            { eLookupGovernorRole.Member_Individual, "Members - individual" },
+            { eLookupGovernorRole.Member_Organisation, "Members - organisation" },
+            { eLookupGovernorRole.Trustee, "Trustees" }
+        };
+
+        public GovernorRoleNameFactory(bool pluralisedName)
+        {
+            _usePluralisedName = pluralisedName;
+        }
+
+        public string Create(eLookupGovernorRole role, eTextCase textCase = eTextCase.SentenceCase)
+        {
+            var temp = _usePluralisedName ?
+                PluralisedLabels.ContainsKey(role) ? PluralisedLabels[role] : SentenceCaseLabels[role]
+                : SentenceCaseLabels[role];
+            return textCase == eTextCase.SentenceCase ? temp : temp.ToLower();
+        }
+    }
+}

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -21,7 +21,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor" },
             { eLookupGovernorRole.Member, "Member" },
             { eLookupGovernorRole.Member_Individual, "Member - individual" },
-            { eLookupGovernorRole.Member_Organisational, "Member - organisational" },
+            { eLookupGovernorRole.Member_Organisation, "Member - organisation" },
             { eLookupGovernorRole.Trustee, "Trustee" },
             {eLookupGovernorRole.NA, "N a" }
         };
@@ -34,7 +34,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors" },
             { eLookupGovernorRole.Member, "Members" },
             { eLookupGovernorRole.Member_Individual, "Members - individual" },
-            { eLookupGovernorRole.Member_Organisational, "Members - organisational" },
+            { eLookupGovernorRole.Member_Organisation, "Members - organisation" },
             { eLookupGovernorRole.Trustee, "Trustees" }
         };
 

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -21,7 +21,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor" },
             { eLookupGovernorRole.Member, "Member" },
             { eLookupGovernorRole.Member_Individual, "Member - individual" },
-            { eLookupGovernorRole.Member_Organisation, "Member - organisation" },
+            { eLookupGovernorRole.Member_Organisation, "Member - organisational" },
             { eLookupGovernorRole.Trustee, "Trustee" },
             {eLookupGovernorRole.NA, "N a" }
         };
@@ -34,7 +34,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors" },
             { eLookupGovernorRole.Member, "Members" },
             { eLookupGovernorRole.Member_Individual, "Members - individual" },
-            { eLookupGovernorRole.Member_Organisation, "Members - organisation" },
+            { eLookupGovernorRole.Member_Organisation, "Members - organisational" },
             { eLookupGovernorRole.Trustee, "Trustees" }
         };
 

--- a/Web/Edubase.ServicesUnitTests/Edubase.ServicesUnitTests.csproj
+++ b/Web/Edubase.ServicesUnitTests/Edubase.ServicesUnitTests.csproj
@@ -49,6 +49,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ExternalLookup\FBServiceTests.cs" />
+    <Compile Include="Governors\Factories\GovernorRoleNameFactoryTests.cs" />
+    <Compile Include="Nomenclature\NomenclatureServiceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -62,6 +64,10 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Edubase.Common\Edubase.Common.csproj">
+      <Project>{8E4A0F2B-368F-4C22-8723-7E234A8C46F3}</Project>
+      <Name>Edubase.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Edubase.Services\Edubase.Services.csproj">
       <Project>{D605ACE4-2659-48DC-BF21-94E7B8D230DA}</Project>
       <Name>Edubase.Services</Name>

--- a/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
         [InlineData(eLookupGovernorRole.Member, "Member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisational, "Member - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -45,7 +45,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
         [InlineData(eLookupGovernorRole.Member, "Members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisational, "Members - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -69,7 +69,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
         [InlineData(eLookupGovernorRole.Member, "member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisational, "member - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "trustee")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -93,7 +93,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
         [InlineData(eLookupGovernorRole.Member, "members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisational, "members - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "trustees")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)

--- a/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
@@ -1,0 +1,117 @@
+using Edubase.Common.Text;
+using Edubase.Services.Enums;
+using Edubase.Services.Governors.Factories;
+using Edubase.Services.Nomenclature;
+using Xunit;
+
+namespace Edubase.ServicesUnitTests.Governors
+{
+    public class GovernorRoleNameFactoryTests
+    {
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "Accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "Chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "Chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "Chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "Chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor")]
+        [InlineData(eLookupGovernorRole.Governor, "Governor")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governor")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
+        [InlineData(eLookupGovernorRole.Member, "Member")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
+        [InlineData(eLookupGovernorRole.NA, "N a")]
+        public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut = new GovernorRoleNameFactory(false);
+
+            var result = sut.Create(role, eTextCase.SentenceCase);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "Accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "Chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "Chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "Chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "Chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors")]
+        [InlineData(eLookupGovernorRole.Governor, "Governors")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governors")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
+        [InlineData(eLookupGovernorRole.Member, "Members")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
+        [InlineData(eLookupGovernorRole.NA, "N a")]
+        public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut = new GovernorRoleNameFactory(true);
+
+            var result = sut.Create(role, eTextCase.SentenceCase);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "shared local governor")]
+        [InlineData(eLookupGovernorRole.Governor, "governor")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governor")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
+        [InlineData(eLookupGovernorRole.Member, "member")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "trustee")]
+        [InlineData(eLookupGovernorRole.NA, "n a")]
+        public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut = new GovernorRoleNameFactory(false);
+
+            var result = sut.Create(role, eTextCase.Lowerase);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "shared local governors")]
+        [InlineData(eLookupGovernorRole.Governor, "governors")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governors")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
+        [InlineData(eLookupGovernorRole.Member, "members")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "trustees")]
+        [InlineData(eLookupGovernorRole.NA, "n a")]
+        public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut = new GovernorRoleNameFactory(true);
+
+            var result = sut.Create(role, eTextCase.Lowerase);
+
+            Assert.Equal(expected, result);
+        }
+
+    }
+}
+

--- a/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
         [InlineData(eLookupGovernorRole.Member, "Member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisational, "Member - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -45,7 +45,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
         [InlineData(eLookupGovernorRole.Member, "Members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisational, "Members - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -69,7 +69,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
         [InlineData(eLookupGovernorRole.Member, "member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisational, "member - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "trustee")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -93,7 +93,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
         [InlineData(eLookupGovernorRole.Member, "members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisational, "members - organisational")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "trustees")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)

--- a/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
@@ -1,7 +1,6 @@
 using Edubase.Common.Text;
 using Edubase.Services.Enums;
 using Edubase.Services.Governors.Factories;
-using Edubase.Services.Nomenclature;
 using Xunit;
 
 namespace Edubase.ServicesUnitTests.Governors
@@ -27,9 +26,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
         {
-            var sut = new GovernorRoleNameFactory(false);
-
-            var result = sut.Create(role, eTextCase.SentenceCase);
+            var result = GovernorRoleNameFactory.Create(role, eTextCase.SentenceCase, false);
 
             Assert.Equal(expected, result);
         }
@@ -53,9 +50,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
         {
-            var sut = new GovernorRoleNameFactory(true);
-
-            var result = sut.Create(role, eTextCase.SentenceCase);
+            var result = GovernorRoleNameFactory.Create(role, eTextCase.SentenceCase, true);
 
             Assert.Equal(expected, result);
         }
@@ -79,9 +74,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
         {
-            var sut = new GovernorRoleNameFactory(false);
-
-            var result = sut.Create(role, eTextCase.Lowerase);
+            var result = GovernorRoleNameFactory.Create(role, eTextCase.Lowerase, false);
 
             Assert.Equal(expected, result);
         }
@@ -105,9 +98,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
         {
-            var sut = new GovernorRoleNameFactory(true);
-
-            var result = sut.Create(role, eTextCase.Lowerase);
+            var result = GovernorRoleNameFactory.Create(role, eTextCase.Lowerase, true);
 
             Assert.Equal(expected, result);
         }

--- a/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Governors/Factories/GovernorRoleNameFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
         [InlineData(eLookupGovernorRole.Member, "Member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisation")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -45,7 +45,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
         [InlineData(eLookupGovernorRole.Member, "Members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisation")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -69,7 +69,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
         [InlineData(eLookupGovernorRole.Member, "member")]
         [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisation")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "trustee")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -93,7 +93,7 @@ namespace Edubase.ServicesUnitTests.Governors
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
         [InlineData(eLookupGovernorRole.Member, "members")]
         [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisation")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisational")]
         [InlineData(eLookupGovernorRole.Trustee, "trustees")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)

--- a/Web/Edubase.ServicesUnitTests/Nomenclature/NomenclatureServiceTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Nomenclature/NomenclatureServiceTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Edubase.Common.Text;
+using Edubase.Services.Enums;
+using Edubase.Services.Governors.Factories;
+using Edubase.Services.Nomenclature;
+using Xunit;
+
+namespace Edubase.ServicesUnitTests.Nomenclature
+{
+    public class NomenclatureServiceTests
+    {
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "Accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "Chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "Chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "Chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "Chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governor")]
+        [InlineData(eLookupGovernorRole.Governor, "Governor")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "Shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governor")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
+        [InlineData(eLookupGovernorRole.Member, "Member")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
+        [InlineData(eLookupGovernorRole.NA, "N a")]
+        public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut1 = new NomenclatureService();
+            var sut = new GovernorRoleNameFactory(false);
+
+            var result1 = sut1.GetGovernorRoleName(role, eTextCase.SentenceCase, false);
+            var result = sut.Create(role);
+
+            Assert.Equal(expected, result1);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors")]
+        [InlineData(eLookupGovernorRole.Governor, "Governors")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "Shared chair of local governing bodies")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governors")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
+        [InlineData(eLookupGovernorRole.Member, "Members")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
+        [InlineData(eLookupGovernorRole.NA, "N as")]
+        public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut1 = new NomenclatureService();
+
+            var result1 = sut1.GetGovernorRoleName(role, eTextCase.SentenceCase, true);
+
+            Assert.Equal(expected, result1);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "accounting officer")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "chair of local governing body")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "chief financial officer")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "shared local governor")]
+        [InlineData(eLookupGovernorRole.Governor, "governor")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "shared chair of local governing body")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governor")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
+        [InlineData(eLookupGovernorRole.Member, "member")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "trustee")]
+        [InlineData(eLookupGovernorRole.NA, "n a")]
+        public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut1 = new NomenclatureService();
+
+            var result1 = sut1.GetGovernorRoleName(role, eTextCase.Lowerase, false);
+
+            Assert.Equal(expected, result1);
+        }
+
+        [Theory]
+        [InlineData(eLookupGovernorRole.AccountingOfficer, "accounting officers")]
+        [InlineData(eLookupGovernorRole.ChairOfGovernors, "chair of governors")]
+        [InlineData(eLookupGovernorRole.ChairOfLocalGoverningBody, "chair of local governing bodies")]
+        [InlineData(eLookupGovernorRole.ChairOfTrustees, "chair of trustees")]
+        [InlineData(eLookupGovernorRole.ChiefFinancialOfficer, "chief financial officers")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, "shared chair of local governing bodies")]
+        [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "shared local governors")]
+        [InlineData(eLookupGovernorRole.Governor, "governors")]
+        [InlineData(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, "shared chair of local governing bodies")]
+        [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governors")]
+        [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
+        [InlineData(eLookupGovernorRole.Member, "members")]
+        [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
+        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisation")]
+        [InlineData(eLookupGovernorRole.Trustee, "trustees")]
+        [InlineData(eLookupGovernorRole.NA, "n as")]
+        public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
+        {
+            var sut1 = new NomenclatureService();
+
+            var result1 = sut1.GetGovernorRoleName(role, eTextCase.Lowerase, true);
+
+            Assert.Equal(expected, result1);
+        }
+
+    }
+}

--- a/Web/Edubase.ServicesUnitTests/Nomenclature/NomenclatureServiceTests.cs
+++ b/Web/Edubase.ServicesUnitTests/Nomenclature/NomenclatureServiceTests.cs
@@ -26,21 +26,16 @@ namespace Edubase.ServicesUnitTests.Nomenclature
         [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governor")]
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governor")]
         [InlineData(eLookupGovernorRole.Member, "Member")]
-        [InlineData(eLookupGovernorRole.Member_Individual, "Member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Member - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustee")]
         [InlineData(eLookupGovernorRole.NA, "N a")]
         public void GetGovernorRoleName_SentenceCase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
         {
-            var sut1 = new NomenclatureService();
-            var sut = new GovernorRoleNameFactory(false);
+            var sut = new NomenclatureService();
 
-            var result1 = sut1.GetGovernorRoleName(role, eTextCase.SentenceCase, false);
-            var result = sut.Create(role);
+            var result = sut.GetGovernorRoleName(role, eTextCase.SentenceCase, false);
 
-            Assert.Equal(expected, result1);
             Assert.Equal(expected, result);
-        }
+         }
 
         [Theory]
         [InlineData(eLookupGovernorRole.Establishment_SharedLocalGovernor, "Shared local governors")]
@@ -49,8 +44,6 @@ namespace Edubase.ServicesUnitTests.Nomenclature
         [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "Shared local governors")]
         [InlineData(eLookupGovernorRole.LocalGovernor, "Local governors")]
         [InlineData(eLookupGovernorRole.Member, "Members")]
-        [InlineData(eLookupGovernorRole.Member_Individual, "Members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "Members - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "Trustees")]
         [InlineData(eLookupGovernorRole.NA, "N as")]
         public void GetGovernorRoleName_SentenceCase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -75,8 +68,6 @@ namespace Edubase.ServicesUnitTests.Nomenclature
         [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governor")]
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governor")]
         [InlineData(eLookupGovernorRole.Member, "member")]
-        [InlineData(eLookupGovernorRole.Member_Individual, "member - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "member - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "trustee")]
         [InlineData(eLookupGovernorRole.NA, "n a")]
         public void GetGovernorRoleName_Lowercase_PluraliseFalse_ReturnsExpected(eLookupGovernorRole role, string expected)
@@ -101,8 +92,6 @@ namespace Edubase.ServicesUnitTests.Nomenclature
         [InlineData(eLookupGovernorRole.Group_SharedLocalGovernor, "shared local governors")]
         [InlineData(eLookupGovernorRole.LocalGovernor, "local governors")]
         [InlineData(eLookupGovernorRole.Member, "members")]
-        [InlineData(eLookupGovernorRole.Member_Individual, "members - individual")]
-        [InlineData(eLookupGovernorRole.Member_Organisation, "members - organisation")]
         [InlineData(eLookupGovernorRole.Trustee, "trustees")]
         [InlineData(eLookupGovernorRole.NA, "n as")]
         public void GetGovernorRoleName_Lowercase_PluraliseTrue_ReturnsExpected(eLookupGovernorRole role, string expected)

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -14,6 +14,7 @@ using Edubase.Services.Establishments;
 using Edubase.Services.Establishments.Models;
 using Edubase.Services.Exceptions;
 using Edubase.Services.Governors;
+using Edubase.Services.Governors.Factories;
 using Edubase.Services.Governors.Models;
 using Edubase.Services.Groups;
 using Edubase.Services.Lookup;
@@ -363,7 +364,8 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
 
             await _layoutHelper.PopulateLayoutProperties(viewModel, establishmentUrn, groupUId, User);
 
-            viewModel.GovernorRoleName = _nomenclatureService.GetGovernorRoleName(role.Value);
+            //viewModel.GovernorRoleName = _nomenclatureService.GetGovernorRoleName(role.Value);
+            viewModel.GovernorRoleName = GovernorRoleNameFactory.Create(role.Value);
             viewModel.GovernorRole = role.Value;
             await PopulateSelectLists(viewModel);
             viewModel.DisplayPolicy =
@@ -672,7 +674,9 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                     .ToList(),
                 NewChairType = ReplaceChairViewModel.ChairType.LocalChair,
                 Role = (eLookupGovernorRole) governor.RoleId,
-                RoleName = _nomenclatureService.GetGovernorRoleName((eLookupGovernorRole) governor.RoleId,
+                //RoleName = _nomenclatureService.GetGovernorRoleName((eLookupGovernorRole) governor.RoleId,
+                //    eTextCase.Lowerase)
+                RoleName = GovernorRoleNameFactory.Create((eLookupGovernorRole) governor.RoleId,
                     eTextCase.Lowerase)
             };
 

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -364,7 +364,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
 
             await _layoutHelper.PopulateLayoutProperties(viewModel, establishmentUrn, groupUId, User);
 
-            //viewModel.GovernorRoleName = _nomenclatureService.GetGovernorRoleName(role.Value);
             viewModel.GovernorRoleName = GovernorRoleNameFactory.Create(role.Value);
             viewModel.GovernorRole = role.Value;
             await PopulateSelectLists(viewModel);
@@ -674,8 +673,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                     .ToList(),
                 NewChairType = ReplaceChairViewModel.ChairType.LocalChair,
                 Role = (eLookupGovernorRole) governor.RoleId,
-                //RoleName = _nomenclatureService.GetGovernorRoleName((eLookupGovernorRole) governor.RoleId,
-                //    eTextCase.Lowerase)
                 RoleName = GovernorRoleNameFactory.Create((eLookupGovernorRole) governor.RoleId,
                     eTextCase.Lowerase)
             };

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -112,8 +112,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             foreach (var role in roles)
             {
                 var equivalantRoles = RoleEquivalence.GetEquivalentToLocalRole(role).Cast<int>().ToList();
-                //var pluralise = !EnumSets.eSingularGovernorRoles.Contains(role);
-
 
                 var grid = new GovernorGridViewModel($"{GovernorRoleNameFactory.Create(role, eTextCase.SentenceCase, true)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
                 {

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -17,6 +17,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
     using Services.Enums;
     using Edubase.Services.Domain;
     using Edubase.Services.Groups.Models;
+    using Edubase.Services.Governors.Factories;
 
     public class GovernorsGridViewModel : Groups.Models.CreateEdit.IGroupPageViewModel, IEstablishmentPageViewModel
     {
@@ -111,10 +112,11 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             foreach (var role in roles)
             {
                 var equivalantRoles = RoleEquivalence.GetEquivalentToLocalRole(role).Cast<int>().ToList();
-                var pluralise = !EnumSets.eSingularGovernorRoles.Contains(role);
+                //var pluralise = !EnumSets.eSingularGovernorRoles.Contains(role);
 
 
-                var grid = new GovernorGridViewModel($"{_nomenclatureService.GetGovernorRoleName(role, eTextCase.SentenceCase, pluralise)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
+                //var grid = new GovernorGridViewModel($"{_nomenclatureService.GetGovernorRoleName(role, eTextCase.SentenceCase, pluralise)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
+                var grid = new GovernorGridViewModel($"{GovernorRoleNameFactory.Create(role, eTextCase.SentenceCase, true)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
                 {
                     Tag = isHistoric ? "historic" : "current",
                     Role = role,
@@ -165,7 +167,8 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                             AppointmentEndDate = new DateTimeViewModel(governor.AppointmentEndDate),
                             AppointmentStartDate = new DateTimeViewModel(governor.AppointmentStartDate),
                             FullName = governor.GetFullName(),
-                            RoleName = _nomenclatureService.GetGovernorRoleName(role)
+                            //RoleName = _nomenclatureService.GetGovernorRoleName(role)
+                            RoleName = GovernorRoleNameFactory.Create(role)
                         };
 
                         HistoricGovernors.Add(gov);

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -115,7 +115,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                 //var pluralise = !EnumSets.eSingularGovernorRoles.Contains(role);
 
 
-                //var grid = new GovernorGridViewModel($"{_nomenclatureService.GetGovernorRoleName(role, eTextCase.SentenceCase, pluralise)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
                 var grid = new GovernorGridViewModel($"{GovernorRoleNameFactory.Create(role, eTextCase.SentenceCase, true)}{(isHistoric ? " (in past 12 months)" : string.Empty)}")
                 {
                     Tag = isHistoric ? "historic" : "current",
@@ -124,7 +123,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     GroupUid = groupUid,
                     EstablishmentUrn = establishmentUrn,
                     IsHistoricRole = isHistoric,
-                    RoleName = _nomenclatureService.GetGovernorRoleName(role)
+                    RoleName = GovernorRoleNameFactory.Create(role)
                 };
 
                 var displayPolicy = dto.RoleDisplayPolicies.Get(role);
@@ -167,7 +166,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                             AppointmentEndDate = new DateTimeViewModel(governor.AppointmentEndDate),
                             AppointmentStartDate = new DateTimeViewModel(governor.AppointmentStartDate),
                             FullName = governor.GetFullName(),
-                            //RoleName = _nomenclatureService.GetGovernorRoleName(role)
                             RoleName = GovernorRoleNameFactory.Create(role)
                         };
 


### PR DESCRIPTION
Governance view - fix the naming of the governor roles on the views
Removes the conversion of an enum to a string - the current conversion code couldn't cope with the new governor role names having '-' e.g 'Member - indiviudal'

The nomenclature service method and associated tests aren't needed now - they're just there to show that I had the existing behaviour covered by tests before I replaced the code. Not sure what to do about that - maybe another PR to remove the unwanted code afterwards.

https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/145544