### PR TITLE
Logic to show edit button on tabs modief to use EditPolicy settings i…

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Controllers/EstablishmentController.cs
@@ -918,7 +918,8 @@ namespace Edubase.Web.UI.Areas.Establishments.Controllers
         private async Task PopulateEditPermissions(EstablishmentDetailViewModel viewModel)
         {
             viewModel.UserCanEdit = await _establishmentReadService.CanEditAsync(viewModel.Establishment.Urn.Value, User);
-            viewModel.TabEditPolicy = new TabEditPolicy(viewModel.Establishment, viewModel.DisplayPolicy, User);
+            var editPolicyEnvelope = await _establishmentReadService.GetEditPolicyAsync(viewModel.Establishment, User);
+            viewModel.TabEditPolicy = new TabEditPolicy(viewModel.Establishment, editPolicyEnvelope.EditPolicy, User);
         }
 
         private async Task PopulateEstablishmentPageViewModel(IEstablishmentPageViewModel viewModel, int urn, string selectedTabName)

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/TabEditPolicy.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/TabEditPolicy.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Principal;
 using Edubase.Common;
 using Edubase.Services.Enums;
@@ -22,6 +23,11 @@ namespace Edubase.Web.UI.Areas.Establishments.Models
         public TabEditPolicy(EstablishmentModel model, EstablishmentDisplayEditPolicy policy, IPrincipal principal)
         {
             Governance = !(principal.IsInRole(EdubaseRoles.ESTABLISHMENT) && model.StatusId.OneOfThese(ES.Closed));
+            Location = new[]
+            {
+                policy.RSCRegionId, policy.GovernmentOfficeRegionId, policy.AdministrativeDistrictId, policy.AdministrativeWardId, policy.ParliamentaryConstituencyId,
+                policy.UrbanRuralId, policy.GSSLAId, policy.Easting, policy.Northing, policy.MSOAId, policy.LSOAId
+            }.Any(x => x == true);
         }
 
         public TabEditPolicy()

--- a/Web/Edubase.Web.UI/Areas/Establishments/Models/TabEditPolicy.cs
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Models/TabEditPolicy.cs
@@ -25,6 +25,7 @@ namespace Edubase.Web.UI.Areas.Establishments.Models
             Governance = !(principal.IsInRole(EdubaseRoles.ESTABLISHMENT) && model.StatusId.OneOfThese(ES.Closed));
             Location = new[]
             {
+                // these fields appear on the Locations tab
                 policy.RSCRegionId, policy.GovernmentOfficeRegionId, policy.AdministrativeDistrictId, policy.AdministrativeWardId, policy.ParliamentaryConstituencyId,
                 policy.UrbanRuralId, policy.GSSLAId, policy.Easting, policy.Northing, policy.MSOAId, policy.LSOAId
             }.Any(x => x == true);


### PR DESCRIPTION
Fix [bug  167518 Permission denied exception](https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_sprints/taskboard/Get%20Information%20About%20Schools/s158-Get-Information-About-Schools/GIAS%20Team/Sprint%2037?workitem=167518)

Change the logic that decides whether to show the edit button on the Locations tab - use EditPolicy settings instead of DisplayPolicy settings. 
TabDisplayPolicy modified to set location to true if any of the Locations fields are editable

I did write some tests but decided that the risk of putting in the refactoring that was needed outweighed the value of the tests.
