### PR TITLE
Add Secure SAT as a filter option when searching for governors

### DIFF
--- a/Web/Edubase.Services/Governors/Search/GovernorSearchPayload.cs
+++ b/Web/Edubase.Services/Governors/Search/GovernorSearchPayload.cs
@@ -16,6 +16,7 @@ namespace Edubase.Services.Governors.Search
             [eGovernorTypesFlag.CTC] = "ctc",   // filtered to governors of City Technology Colleges
             [eGovernorTypesFlag.FreeSchools] = "freeschools",   // filtered to governors of Free Schools
             [eGovernorTypesFlag.AcadsWithSchoolSponsor] = "acads_with_sch_spon",   // filtered to governors of Academies with a School Sponsor
+            [eGovernorTypesFlag.SecureSingleAcademyTrusts] = "ssats",   // filtered to governors associated with Secure SATs
         };
 
         public GovernorSearchPayload()
@@ -28,7 +29,7 @@ namespace Edubase.Services.Governors.Search
             Skip = skip;
             Take = take;
         }
-        
+
         [JsonProperty("governorId")]
         public string Gid { get; set; }
         public string FirstName { get; set; }

--- a/Web/Edubase.Services/Governors/Search/eGovernorTypesFlag.cs
+++ b/Web/Edubase.Services/Governors/Search/eGovernorTypesFlag.cs
@@ -8,6 +8,7 @@
         GovsOfLAMaintained, // filtered to governors of LA maintained type establishments
         CTC, // filtered to governors of City Technology Colleges
         FreeSchools, // filtered to governors of Free Schools
-        AcadsWithSchoolSponsor // filtered to governors of Academies with a School Sponsor
+        AcadsWithSchoolSponsor, // filtered to governors of Academies with a School Sponsor
+        SecureSingleAcademyTrusts // filtered to governors associated with Secure SATs
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorSearchViewModel.cs
@@ -30,6 +30,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             new LookupItemViewModel((int)eGovernorTypesFlag.CTC, "City technology colleges"),
             new LookupItemViewModel((int)eGovernorTypesFlag.FreeSchools, "Free schools"),
             new LookupItemViewModel((int)eGovernorTypesFlag.AcadsWithSchoolSponsor, "Academies with a school sponsor"),
+            new LookupItemViewModel((int)eGovernorTypesFlag.SecureSingleAcademyTrusts, "Secure single-academy trusts"),
         };
 
         public IEnumerable<LookupItemViewModel> LocalAuthorities { get; set; }


### PR DESCRIPTION
This adds filtering by Secure SAT as an option when searching for governors. The corresponding backend change is in place and manual tests locally confirm this to be working.

#164278

![image](https://github.com/DFE-Digital/get-information-about-schools/assets/96429508/7ed5719e-94c1-42c7-ae65-41c78991daa4)
