### PR TITLE
Update to allow DSI to work with GIAS behind proxy/WAF

### DIFF
--- a/Web/Edubase.Web.UI/App_Start/StartupSecureAccess.cs
+++ b/Web/Edubase.Web.UI/App_Start/StartupSecureAccess.cs
@@ -30,6 +30,7 @@ namespace Edubase.Web.UI
         public static string ApplicationIdpEntityId => AppSettings[nameof(ApplicationIdpEntityId)];
         public static Uri ExternalAuthDefaultCallbackUrl => new Uri(AppSettings[nameof(ExternalAuthDefaultCallbackUrl)]);
         public static Uri MetadataLocation => new Uri(AppSettings[nameof(MetadataLocation)]);
+        public static Uri PublicOrigin => string.IsNullOrWhiteSpace(AppSettings[nameof(PublicOrigin)]) ? null : new Uri(AppSettings[nameof(PublicOrigin)]);
 
         public void ConfigureAuth(IAppBuilder app)
         {
@@ -83,6 +84,12 @@ namespace Edubase.Web.UI
                 ReturnUrl = ExternalAuthDefaultCallbackUrl,
                 MinIncomingSigningAlgorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
             };
+
+            if (PublicOrigin != null)
+            {
+                // Only set if provided via configuration
+                spOptions.PublicOrigin = PublicOrigin;
+            }
 
             var authServicesOptions = new Saml2AuthenticationOptions(false) { SPOptions = spOptions };
 

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -268,11 +268,16 @@
       - `SessionExpireTimeSpan`           The duration (hh:MM:ss) for which the session cookie remains valid,
                                             - specifically the `Expires/Max-Age` field on the cookie.
                                             - See also: Edubase.Web.UI.StartupSecureAccess.ConfigureAuth
+      - `PublicOrigin`                    The URL of the GIAS website, as seen by the Identity Provider (IDP).
+                                          This may be required if the GIAS website is hosted behind a proxy/WAF.
+                                          Omitting this setting will default to using the value provided by `request.ApplicationUrl`.
+                                          See also #157607 and #171878.
     -->
     <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase" />
     <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback" />
     <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata" />
     <add key="SessionExpireTimeSpan" value="00:59:00" />
+    <!-- <add key="PublicOrigin" value="" /> -->
 
     <!--
       SA/DSI Simulator configuration


### PR DESCRIPTION
Add configuration option for `PublicOrigin`, to allow redirects to a proxy/WAF URL different to the server's application URL.

#157607 #171878