### PR TITLE
Allow multiline validation messages for appointed by

### DIFF
--- a/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
+++ b/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
@@ -289,6 +290,24 @@ namespace Edubase.Web.UI.Helpers
             dropdown.MergeAttributes(new RouteValueDictionary(htmlAttributes));
 
             return MvcHtmlString.Create(dropdown.ToString(TagRenderMode.Normal));
+        }
+
+        /// <summary>
+        /// Where the input contains a raw newline character (<c>\r\n</c>, <c>\r</c>, or <c>\n</c>),
+        /// replace it with an HTML newline tag <c>&lt;br/&gt;</c>.
+        /// </summary>
+        /// <param name="helper"></param>
+        /// <param name="input">The input string to have raw newlines replaced with HTML newline tags.</param>
+        /// <returns>
+        ///     The original string as an <see cref="MvcHtmlString"/>.
+        ///     <list type="bullet">
+        ///         <item>If no newlines in the input string, it is an as-is copy.</item>
+        ///         <item>If one or more raw newlines, these will be HTML newlines.</item>
+        ///     </list>
+        /// </returns>
+        public static MvcHtmlString HtmlNewlines(this HtmlHelper helper, string input)
+        {
+            return new MvcHtmlString(Regex.Replace(helper.Encode(input), "\r|\n|\r\n", "<br/>"));
         }
     }
 }

--- a/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
+++ b/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
@@ -309,5 +309,23 @@ namespace Edubase.Web.UI.Helpers
         {
             return new MvcHtmlString(Regex.Replace(helper.Encode(input), "\r|\n|\r\n", "<br/>"));
         }
+
+        /// <summary>
+        /// Where the input contains a raw newline character (<c>\r\n</c>, <c>\r</c>, or <c>\n</c>),
+        /// replace it with an HTML newline tag <c>&lt;br/&gt;</c>.
+        /// </summary>
+        /// <param name="helper"></param>
+        /// <param name="input">The input string to have raw newlines replaced with HTML newline tags.</param>
+        /// <returns>
+        ///     The original string as an <see cref="MvcHtmlString"/>.
+        ///     <list type="bullet">
+        ///         <item>If no newlines in the input string, it is an as-is copy.</item>
+        ///         <item>If one or more raw newlines, these will be HTML newlines.</item>
+        ///     </list>
+        /// </returns>
+        public static MvcHtmlString HtmlNewlines(this HtmlHelper helper, MvcHtmlString input)
+        {
+            return new MvcHtmlString(Regex.Replace(helper.Encode(input), "\r|\n|\r\n", "<br/>"));
+        }
     }
 }

--- a/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
@@ -57,7 +57,7 @@
 {
     <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.AppointingBodyId)">
         @Html.LabelFor(x => x.AppointingBodyId, "Appointing body (required to save record)", new { @class = "govuk-label" })
-        @Html.ValidationMessageFor(x => x.AppointingBodyId, null, new { @class = "govuk-error-message" })
+        @Html.HtmlNewlines(Html.ValidationMessageFor(x => x.AppointingBodyId, null, new { @class = "govuk-error-message" }))
         @Html.DropDownListFor(x => x.AppointingBodyId, Model.AppointingBodies, "", new { @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.AppointingBodyId)) })
     </div>
 }

--- a/Web/Edubase.Web.UI/Views/Shared/_ValidationSummary.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/_ValidationSummary.cshtml
@@ -24,7 +24,9 @@
                     foreach (var modelError in Model.Keys.SelectMany(key => this.Model[key].Errors.Select(x => Tuple.Create(key, x.ErrorMessage))))
                     {
                         <li>
-                            <a id="error-summary-@StringUtils.ElementIdFormat(@modelError.Item1)-list-item" href='#@modelError.Item1.Replace(".", "_").Replace("[", "_").Replace("]", "_")'>@modelError.Item2</a>
+                            <a id="error-summary-@StringUtils.ElementIdFormat(@modelError.Item1)-list-item" href='#@modelError.Item1.Replace(".", "_").Replace("[", "_").Replace("]", "_")'>
+                                @Html.HtmlNewlines(modelError.Item2)
+                            </a>
                         </li>
                     }
                 }


### PR DESCRIPTION
As required in #154938, the validation message for the "appointed by" field is a multi-line message.

This change introduces a new helper to replace raw newline characters (`\r`, `\n`, and `\r\n`) within the error messages supplied by the backend API, and use HTML newline tags (`<br/>`) to display the newlines correctly on the web page.

The helper has been applied to all validation messages in the summary top-box, and only the appointed by field for the validation message next to the field.

