### PR TITLE
Remove nuget caching

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,6 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  
-  ## When caching the dependencies, should specify a directory path for consistency
-  NUGET_PACKAGES_DIR: $(Pipeline.Workspace)/.nuget/packages
 
   ## These variables distinguish between "dev" (incl. AFD/custom domain) and sandboxes
   isDev:      $[eq(variables['Build.SourceBranch'], 'refs/heads/dev')]
@@ -102,7 +99,6 @@ stages:
           thisJobName: 'BuildTestAndPackageJob'
           version: $(version)
           artifactReference: 'BuiltAndPackagedWebUiZip'
-          nugetPackagesDirectory: '$(NUGET_PACKAGES_DIR)'
   
   
   

--- a/pipelines/template-build-and-test.yml
+++ b/pipelines/template-build-and-test.yml
@@ -13,8 +13,6 @@
   - name: version
   - name: artifactReference
     default: 'BuiltAndPackagedWebUiZip'
-  - name: nugetPackagesDirectory
-    default: '$(Pipeline.Workspace)/.nuget/packages'
 
 
 
@@ -120,20 +118,6 @@ jobs:
 
       - task: NuGetToolInstaller@1
         displayName: 'Install NuGet'
-      
-      ## https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#netnuget
-      - task: Cache@2
-        displayName: Cache C# dependencies
-        inputs:
-          ## Should probably do this based on packages.lock.json, but this requires enabling it first
-          ## See: https://devblogs.microsoft.com/nuget/enable-repeatable-package-restores-using-a-lock-file/
-          #key: 'nuget | "$(Agent.OS)" | $(Build.SourcesDirectory)/**/packages.lock.json'
-          key: 'nuget | "$(Agent.OS)" | **/packages.config,**/*.csproj,!**/bin/**,!**/obj/**'
-          restoreKeys: |
-            nuget | "$(Agent.OS)"
-            nuget
-          path: '$(nugetPackagesDirectory)'
-          cacheHitVar: 'CACHE_RESTORED'
 
       - task: NuGetCommand@2
         displayName: Restore C# solution


### PR DESCRIPTION
Nuget dependency caching issues is causing problems since merging into dev and unable to immediately resolve, so this PR is removing caching to allow pipeline runs to progress We can re-add this optimisation back later.