### PR TITLE
Failing validation adding chair of trustees causes the "Original chai…

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -492,6 +492,12 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 await _governorsReadService.GetEditorDisplayPolicyAsync(viewModel.GovernorRole,
                     viewModel.GroupUId.HasValue, User);
 
+            if (viewModel.GroupTypeId != 11)
+            {
+                viewModel.DisplayPolicy.IsOriginalChairOfTrustees = false;
+                viewModel.DisplayPolicy.IsOriginalSignatoryMember = false;
+            }
+
             var governorModel = new GovernorModel
             {
                 AppointingBodyId = viewModel.AppointingBodyId,


### PR DESCRIPTION
…r of trustees" to be visible for a MAT where it should not be.

The controller method that calls the java api to add this now has the code that modifies the display policy where the group is not secure 16-19.  This makes the field invisible where the group is not type 11.  The code originally had this on the get method for AddEditOrReplace now it is also included on the post.

This was required because the group type is not one of the parameters for the api.  Each time the display policy is reloaded from the api this modification would be required or the values reset to true.  It appears this was done to save adding the extra paramater to the java api.