### PR TITLE
Configurable FSCPD service name

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
@@ -280,7 +280,7 @@
                 {
             <li>
                 <a href="@Model.FscpdURL" rel="noreferrer noopener" target="_blank">
-                    Find school and college performance data in England (opens in new tab)
+                    @Model.FscpdServiceName (opens in new tab)
                 </a>
             </li>
                 }

--- a/Web/Edubase.Web.UI/Areas/Groups/Models/GroupDetailViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Groups/Models/GroupDetailViewModel.cs
@@ -66,6 +66,7 @@ namespace Edubase.Web.UI.Areas.Groups.Models
         public IEnumerable<LinkedGroupModel> Links { get; set; }
         public GovernorPermissions GovernorPermissions { get; set; }
 
+        public string FscpdServiceName => ConfigurationManager.AppSettings["FscpdServiceName"];
         public string FscpdURL => extService.FscpdURL(Group.GroupUId, Group.Name, GroupTypeId.OneOfThese(eLookupGroupType.MultiacademyTrust, eLookupGroupType.SchoolSponsor));
         private bool? showFscpd;
         public bool ShowFscpd

--- a/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Groups/Views/Group/Details.cshtml
@@ -469,7 +469,7 @@
                                     {
                                         <li>
                                             <a href="@Model.FscpdURL" rel="noreferrer noopener" target="_blank">
-                                                Find school and college performance data in England (opens in new tab)
+                                                @Model.FscpdServiceName (opens in new tab)
                                             </a>
                                         </li>
                                     }

--- a/Web/Edubase.Web.UI/Models/EstablishmentDetailViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/EstablishmentDetailViewModel.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using Edubase.Web.UI.Areas.Establishments.Models;
 using Edubase.Services.Core;
 using Edubase.Web.UI.Helpers;
-using System;
+using System.Configuration;
 using System.Linq;
 using System.Threading.Tasks;
 using Edubase.Services.ExternalLookup;
@@ -189,6 +189,7 @@ namespace Edubase.Web.UI.Models
         public bool HighPriorityEstablishmentConfirmationPending => (Establishment?.UrgentConfirmationUpToDateRequired).GetValueOrDefault();
         public bool HighPriorityGovernanceConfirmationPending => (Establishment?.UrgentConfirmationUpToDateGovernanceRequired).GetValueOrDefault();
 
+        public string FscpdServiceName => ConfigurationManager.AppSettings["FscpdServiceName"];
         public string FscpdURL => extService.FscpdURL(Establishment.Urn, Establishment.Name, Establishment.TypeId.OneOfThese(eLookupGroupType.MultiacademyTrust));
         private bool? showFscpd;
         public bool ShowFscpd

--- a/Web/Edubase.Web.UI/Models/HomepageViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/HomepageViewModel.cs
@@ -12,6 +12,7 @@ namespace Edubase.Web.UI.Models
         }
         public IEnumerable<NewsArticle> NewsArticles { get; set; }
         public string FinancialBenchmarkingHomepage => ConfigurationManager.AppSettings["FinancialBenchmarkingURL"];
+        public string FscpdServiceName => ConfigurationManager.AppSettings["FscpdServiceName"];
         public string FscpdHomepage => ConfigurationManager.AppSettings["FscpdHomeUrl"];
     }
 }

--- a/Web/Edubase.Web.UI/Views/Guidance/General.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/General.cshtml
@@ -1,7 +1,12 @@
+@using System.Configuration
+
 @{
     ViewBag.Title = "Get Information about Schools";
     ViewBag.imageMQ = "(max-width: 768px)";
     ViewBag.SiteSection = "help";
+
+    var fscpdServiceName = ConfigurationManager.AppSettings["FscpdServiceName"];
+    var fscpdHomeUrl = ConfigurationManager.AppSettings["FscpdHomeUrl"];
 }
 @section BreadCrumbs
 {
@@ -45,7 +50,7 @@
         </ul>
 
         <p>Each group of users accesses their data through a separate online portal. Each portal provides access to Get Information about Schools functions available for a specific user group.</p>
-        <p>Get Information about Schools is mainly intended as resource for educational professionals. Parents and guardians are likely to find <a href="https://www.gov.uk/school-performance-tables" target="_blank" rel="noreferrer noopener">Find school and college performance data in England (opens in new tab)</a> more helpful to meet their needs</p>
+        <p>Get Information about Schools is mainly intended as resource for educational professionals. Parents and guardians are likely to find <a href="@fscpdHomeUrl" target="_blank" rel="noreferrer noopener">@fscpdServiceName (opens in new tab)</a> more helpful to meet their needs</p>
 
         <h2 class="govuk-heading-m">How to log in</h2>
         <p>If you are an educational professional and you need to log in to Get Information about Schools, click on the top menu bar &lsquo;Sign in&rsquo; link which will take you to the login page.</p>

--- a/Web/Edubase.Web.UI/Views/Home/Index.cshtml
+++ b/Web/Edubase.Web.UI/Views/Home/Index.cshtml
@@ -128,7 +128,7 @@
             <div class="govuk-grid-column-one-half @groupSpacing">
                 <ul class="govuk-list">
                     <li>
-                        <h3 class="govuk-heading-m">Find and Compare Schools in England</h3>
+                        <h3 class="govuk-heading-m">@Model.FscpdServiceName</h3>
                         <p>
                             Search and compare performance information about schools and further education colleges in England
                         </p>

--- a/Web/Edubase.Web.UI/Views/Home/Responsibilities.cshtml
+++ b/Web/Edubase.Web.UI/Views/Home/Responsibilities.cshtml
@@ -1,6 +1,10 @@
+@using System.Configuration
 @{
     ViewBag.Title = "Get Information about Schools";
     ViewBag.SiteSection = "help";
+
+    var fscpdServiceName = ConfigurationManager.AppSettings["FscpdServiceName"];
+    var fscpdHomeUrl = ConfigurationManager.AppSettings["FscpdHomeUrl"];
 }
 
 @section BreadCrumbs
@@ -55,7 +59,7 @@
                     <li data-idx="2.2">
                         Key departmental services, such as
                         <a href="https://services.signin.education.gov.uk/" target="_blank" rel="noreferrer noopener">DfE Sign-in (DSI) (opens in new tab)</a>,
-                        <a href="https://www.gov.uk/school-performance-tables" target="_blank" rel="noreferrer noopener">Find school and college performance data in England (FSCP) (also known as the School Performance Tables (SPT)) (opens in new tab)</a>,
+                        <a href="@fscpdHomeUrl" target="_blank" rel="noreferrer noopener">@fscpdServiceName (also known as the School Performance Tables (SPT)) (opens in new tab)</a>,
                         Analyse School Performance (ASP) and
                         <a href="https://schools-financial-benchmarking.service.gov.uk/" target="_blank" rel="noreferrer noopener">School Financial Benchmarking (SFB) (opens in new tab)</a>
                         use the information in GIAS to directly feed their services. If GIAS information is incorrect establishments (where applicable) may not be represented correctly on these key services that are available to the public and/or individual establishments.
@@ -89,7 +93,7 @@
                     <li data-idx="2.10">
                         All governance boards are required to provide information to the Secretary of State about people involved in governance via GIAS which is also the
                         <a href="https://www.gov.uk/government/news/national-database-of-governors" target="_blank" rel="noreferrer noopener">National Database of Governors (opens in new tab)</a>.
-                        <a href="http://www.legislation.gov.uk/ukpga/1996/56/section/538" target="_blank" rel="noreferrer noopener">Section 538 of the Education Act 1996 (opens in new tab)</a> and the 
+                        <a href="http://www.legislation.gov.uk/ukpga/1996/56/section/538" target="_blank" rel="noreferrer noopener">Section 538 of the Education Act 1996 (opens in new tab)</a> and the
                         <a href="https://www.gov.uk/guidance/academies-financial-handbook" target="_blank" rel="noreferrer noopener">Academy Trust Handbook (opens in new tab)</a> provide further information about establishments responsibilities with regards to GIAS.
                     </li>
                     <li data-idx="2.11">

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -251,8 +251,6 @@
       - `FscpdPassword`     (Not normally supplied) Basic auth username to access the FSCPD service.
     -->
     <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
-    <!-- <add key="FscpdURL" value="https://www.find-school-performance-data.service.gov.uk/" /> -->
-    <!-- <add key="FscpdServiceName" value="Find school and college performance data in England" /> -->
     <add key="FscpdURL" value="https://www.compare-school-performance.service.gov.uk/" />
     <add key="FscpdServiceName" value="Compare school and college performance in England" />
     <add key="FscpdCacheHours" value="72" />

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -243,6 +243,7 @@
 
       - `FscpdHomeUrl`      URL linked to from the GIAS home page
       - `FscpdURL`          Base URL linked to from establishment/MAT details pages
+      - `FscpdServiceName`  Name of the service to use within links (set via configuration as this has changed several times)
       - `FscpdCacheHours`   GIAS only shows the establishment/MAT-specific link if GIAS has been able to
                             confirm that the associated FSCPD page exists.
                             This setting configures the maximum age of the check result.
@@ -250,7 +251,10 @@
       - `FscpdPassword`     (Not normally supplied) Basic auth username to access the FSCPD service.
     -->
     <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
-    <add key="FscpdURL" value="https://cscp-dev-web.azurewebsites.net/" />
+    <!-- <add key="FscpdURL" value="https://www.find-school-performance-data.service.gov.uk/" /> -->
+    <!-- <add key="FscpdServiceName" value="Find school and college performance data in England" /> -->
+    <add key="FscpdURL" value="https://www.compare-school-performance.service.gov.uk/" />
+    <add key="FscpdServiceName" value="Compare school and college performance in England" />
     <add key="FscpdCacheHours" value="72" />
     <add key="FscpdUsername" value="" />
     <add key="FscpdPassword" value="" />


### PR DESCRIPTION
This PR introduces a configurable service name for FSCPD/CSCP (following renames), defaulting to the new CSCP name. 

This configurable service name is currently used only on the establishment and group details pages for now, while clarification about the home page and help page is being sought.