### PR TITLE
188811 / 190689 - notification banner thread issues

### DIFF
--- a/Web/Edubase.Data/Edubase.Data.csproj
+++ b/Web/Edubase.Data/Edubase.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')"/>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -12,7 +12,7 @@
     <AssemblyName>Edubase.Data</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile/>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -114,55 +114,56 @@
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data.Entity.Design" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Security" />
+    <Reference Include="System"/>
+    <Reference Include="System.ComponentModel.DataAnnotations"/>
+    <Reference Include="System.Configuration"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="System.Data.Entity.Design"/>
+    <Reference Include="System.Net"/>
+    <Reference Include="System.Net.Http"/>
+    <Reference Include="System.Net.Http.WebRequest"/>
+    <Reference Include="System.Runtime"/>
+    <Reference Include="System.Runtime.Caching"/>
+    <Reference Include="System.Runtime.Serialization"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Security"/>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml"/>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DbGeographyConverter.cs" />
-    <Compile Include="Entity\FaqGroup.cs" />
-    <Compile Include="Entity\FaqItem.cs" />
-    <Compile Include="Entity\NewsArticle.cs" />
-    <Compile Include="Entity\NotificationBanner.cs" />
-    <Compile Include="Entity\NotificationTemplate.cs" />
-    <Compile Include="Entity\Token.cs" />
-    <Compile Include="Entity\LocalAuthoritySet.cs" />
-    <Compile Include="Entity\GlossaryItem.cs" />
-    <Compile Include="Entity\ApiRecorderSessionItem.cs" />
-    <Compile Include="Entity\DataQualityStatus.cs" />
-    <Compile Include="Entity\UserPreference.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Repositories\DataQualityStatusRepository.cs" />
-    <Compile Include="Repositories\FaqGroupRepository.cs" />
-    <Compile Include="Repositories\FaqItemRepository.cs" />
-    <Compile Include="Repositories\ILocalAuthoritySetRepository.cs" />
-    <Compile Include="Repositories\ITokenRepository.cs" />
-    <Compile Include="Repositories\IUserPreferenceRepository.cs" />
-    <Compile Include="Repositories\NewsArticleRepository.cs" />
-    <Compile Include="Repositories\NotificationBannerRepository.cs" />
-    <Compile Include="Repositories\NotificationTemplateRepository.cs" />
-    <Compile Include="Repositories\UserPreferenceRepository.cs" />
-    <Compile Include="Repositories\TokenRepository.cs" />
-    <Compile Include="Repositories\LocalAuthoritySetRepository.cs" />
-    <Compile Include="Repositories\IDataQualityStatusRepository.cs" />
-    <Compile Include="Repositories\ApiRecorderSessionItemRepository.cs" />
-    <Compile Include="Repositories\GlossaryRepository.cs" />
-    <Compile Include="Repositories\TableStorage\Page.cs" />
-    <Compile Include="Repositories\TableStorage\TableStorageBase.cs" />
+    <Compile Include="DbGeographyConverter.cs"/>
+    <Compile Include="Entity\FaqGroup.cs"/>
+    <Compile Include="Entity\FaqItem.cs"/>
+    <Compile Include="Entity\NewsArticle.cs"/>
+    <Compile Include="Entity\NotificationBanner.cs"/>
+    <Compile Include="Entity\NotificationTemplate.cs"/>
+    <Compile Include="Entity\Token.cs"/>
+    <Compile Include="Entity\LocalAuthoritySet.cs"/>
+    <Compile Include="Entity\GlossaryItem.cs"/>
+    <Compile Include="Entity\ApiRecorderSessionItem.cs"/>
+    <Compile Include="Entity\DataQualityStatus.cs"/>
+    <Compile Include="Entity\UserPreference.cs"/>
+    <Compile Include="Properties\AssemblyInfo.cs"/>
+    <Compile Include="Repositories\DataQualityStatusRepository.cs"/>
+    <Compile Include="Repositories\FaqGroupRepository.cs"/>
+    <Compile Include="Repositories\FaqItemRepository.cs"/>
+    <Compile Include="Repositories\ILocalAuthoritySetRepository.cs"/>
+    <Compile Include="Repositories\ITokenRepository.cs"/>
+    <Compile Include="Repositories\IUserPreferenceRepository.cs"/>
+    <Compile Include="Repositories\NewsArticleRepository.cs"/>
+    <Compile Include="Repositories\NotificationBannerRepository.cs"/>
+    <Compile Include="Repositories\NotificationTemplateRepository.cs"/>
+    <Compile Include="Repositories\UserPreferenceRepository.cs"/>
+    <Compile Include="Repositories\TokenRepository.cs"/>
+    <Compile Include="Repositories\LocalAuthoritySetRepository.cs"/>
+    <Compile Include="Repositories\IDataQualityStatusRepository.cs"/>
+    <Compile Include="Repositories\ApiRecorderSessionItemRepository.cs"/>
+    <Compile Include="Repositories\GlossaryRepository.cs"/>
+    <Compile Include="Repositories\TableStorage\Page.cs"/>
+    <Compile Include="Repositories\TableStorage\TableStorageBase.cs"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Edubase.Common\Edubase.Common.csproj">
@@ -171,22 +172,22 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="App.config"/>
+    <None Include="packages.config"/>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
-    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))"/>
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))"/>
   </Target>
-  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
+  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')"/>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
+++ b/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
@@ -79,10 +79,10 @@ namespace Edubase.Data.Repositories
 
         private DateTime CalculateDateTimeOfCacheExpiration(IEnumerable<NotificationBanner> currentBanners)
         {
-            if (!int.TryParse(ConfigurationManager.AppSettings["NotificationBannerCacheExpirationInMinutes"],
-                    out var maximumCacheExpirationInMinutes))
+            if (!int.TryParse(ConfigurationManager.AppSettings["NotificationBannerCacheExpirationInSeconds"],
+                    out var maximumCacheExpirationInSeconds))
             {
-                maximumCacheExpirationInMinutes = 5;
+                maximumCacheExpirationInSeconds = 300;
             }
 
             var futureBannersQuery = Table.CreateQuery<NotificationBanner>()
@@ -97,7 +97,7 @@ namespace Edubase.Data.Repositories
             expirationTimes = expirationTimes.Union((from banner in futureBanners
                 select banner.Start).ToList()).ToList();
 
-            expirationTimes.Add(DateTime.Now.AddMinutes(maximumCacheExpirationInMinutes));
+            expirationTimes.Add(DateTime.Now.AddSeconds(maximumCacheExpirationInSeconds));
 
             return expirationTimes.Min();
         }

--- a/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
+++ b/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
@@ -57,10 +57,10 @@ namespace Edubase.Data.Repositories
         {
             var cache = MemoryCache.Default;
             var result = cache[TopTwoNotificationBannersCacheKey] as IEnumerable<NotificationBanner>;
-            return result ?? RetrieveAndUpdateTopTwoNotificationBannersFromCache();
+            return result ?? GetTopTwoNotificationBannersFromTableAndUpdateCache();
         }
 
-        private IEnumerable<NotificationBanner> RetrieveAndUpdateTopTwoNotificationBannersFromCache()
+        private IEnumerable<NotificationBanner> GetTopTwoNotificationBannersFromTableAndUpdateCache()
         {
             if (!int.TryParse(ConfigurationManager.AppSettings["NotificationBannerCacheExpirationInMinutes"],
                     out var cacheExpirationInMinutes))

--- a/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
+++ b/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
@@ -1,30 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Runtime.Caching;
+using System.Threading;
+using System.Threading.Tasks;
 using Edubase.Data.Entity;
 using Edubase.Data.Repositories.TableStorage;
 using Microsoft.WindowsAzure.Storage.Table;
-using System.Threading.Tasks;
-using MoreLinq;
-using System.Collections.Generic;
-using System.Linq;
-using System;
 using Microsoft.WindowsAzure.Storage.Table.Queryable;
+using MoreLinq;
 
 namespace Edubase.Data.Repositories
 {
-    public class NotificationBannerRepository : TableStorageBase<NotificationBanner>// INotificationBannerRepository
+    public class NotificationBannerRepository : TableStorageBase<NotificationBanner> // INotificationBannerRepository
     {
+        private const string TopTwoNotificationBannersCacheKey = "topTwoCurrentNotificationBanners";
+
         public NotificationBannerRepository()
             : base("DataConnectionString")
         {
         }
 
-        public async Task CreateAsync(NotificationBanner entity) => await Table.ExecuteAsync(TableOperation.Insert(entity));
+        public async Task CreateAsync(NotificationBanner entity)
+        {
+            await Table.ExecuteAsync(TableOperation.Insert(entity));
+        }
 
         public async Task CreateAsync(params NotificationBanner[] entities)
         {
             /*
-             * A batch operation is a collection of table operations which are executed by the Storage Service REST API as a 
-             * single atomic operation, by invoking an Entity Group Transaction. A batch operation may contain up to 100 individual table operations, 
-             * with the requirement that each operation entity must have same partition key. A batch with a retrieve operation cannot contain 
+             * A batch operation is a collection of table operations which are executed by the Storage Service REST API as a
+             * single atomic operation, by invoking an Entity Group Transaction. A batch operation may contain up to 100 individual table operations,
+             * with the requirement that each operation entity must have same partition key. A batch with a retrieve operation cannot contain
              * any other operations. Note that the total payload of a batch operation is limited to 4MB.
              */
             var partitionKeys = entities.Select(x => x.PartitionKey).Distinct();
@@ -40,35 +48,66 @@ namespace Edubase.Data.Repositories
             }
         }
 
-        public async Task CreateAsync(IEnumerable<NotificationBanner> entities) => await CreateAsync(entities.ToArray());
-
-        public Page<NotificationBanner> GetAll(int take, TableContinuationToken skip = null, bool visibleOnly = true, eNotificationBannerPartition partitionKey = eNotificationBannerPartition.Current)
+        public async Task CreateAsync(IEnumerable<NotificationBanner> entities)
         {
-            var query = Table.CreateQuery<NotificationBanner>().Where(x => x.PartitionKey == partitionKey.ToString()).AsQueryable();
-            if (visibleOnly)
-            {
-                query = query.Where(x => x.Start <= DateTime.Now && x.End >= DateTime.Now);
-            }
-            query = query.Take(take);
-            var results = Table.ExecuteQuerySegmentedAsync(query.AsTableQuery(), skip).Result;
-            return new Page<NotificationBanner>(results, results.ContinuationToken);
+            await CreateAsync(entities.ToArray());
         }
 
-        public async Task<Page<NotificationBanner>> GetAllAsync(int take, TableContinuationToken skip = null, bool excludeExpired = false, eNotificationBannerPartition partitionKey = eNotificationBannerPartition.Current)
+        public IEnumerable<NotificationBanner> GetTopTwoCurrentNotificationBanners()
         {
-            var query = Table.CreateQuery<NotificationBanner>().Where(x => x.PartitionKey == partitionKey.ToString()).AsQueryable();
+            var cache = MemoryCache.Default;
+            var result = cache[TopTwoNotificationBannersCacheKey] as IEnumerable<NotificationBanner>;
+            return result ?? RetrieveAndUpdateTopTwoNotificationBannersFromCache();
+        }
+
+        private IEnumerable<NotificationBanner> RetrieveAndUpdateTopTwoNotificationBannersFromCache()
+        {
+            if (!int.TryParse(ConfigurationManager.AppSettings["NotificationBannerCacheExpirationInMinutes"],
+                    out var cacheExpirationInMinutes))
+            {
+                cacheExpirationInMinutes = 5;
+            }
+
+            var cache = MemoryCache.Default;
+
+            var query =
+                Table.CreateQuery<NotificationBanner>()
+                    .Where(x => x.PartitionKey == eNotificationBannerPartition.Current.ToString()
+                                && x.Start <= DateTime.Now
+                                && x.End >= DateTime.Now)
+                    .Take(2).AsTableQuery();
+            var notificationBanners = Table.ExecuteQuery(query).ToList();
+            Console.WriteLine("current thread is background: " + Thread.CurrentThread.IsBackground);
+
+            //the cache only adds values if they don't exist - the method name doesn't make this clear.
+            cache.Add(TopTwoNotificationBannersCacheKey,
+                notificationBanners,
+                new DateTimeOffset(DateTime.Now.AddMinutes(cacheExpirationInMinutes)));
+
+            return notificationBanners;
+        }
+
+        public async Task<Page<NotificationBanner>> GetAllAsync(int take, TableContinuationToken skip = null,
+            bool excludeExpired = false,
+            eNotificationBannerPartition partitionKey = eNotificationBannerPartition.Current)
+        {
+            var query = Table.CreateQuery<NotificationBanner>().Where(x => x.PartitionKey == partitionKey.ToString())
+                .AsQueryable();
             if (excludeExpired)
             {
                 query = query.Where(x => x.End >= DateTime.Now);
             }
+
             query = query.Take(take);
             var results = await Table.ExecuteQuerySegmentedAsync(query.AsTableQuery(), skip);
             return new Page<NotificationBanner>(results, results.ContinuationToken);
         }
 
-        public async Task<NotificationBanner> GetAsync(string id, eNotificationBannerPartition partitionKey = eNotificationBannerPartition.Current)
+        public async Task<NotificationBanner> GetAsync(string id,
+            eNotificationBannerPartition partitionKey = eNotificationBannerPartition.Current)
         {
-            var q = Table.CreateQuery<NotificationBanner>().Where(x => x.PartitionKey == partitionKey.ToString() && x.RowKey == id).AsTableQuery();
+            var q = Table.CreateQuery<NotificationBanner>()
+                .Where(x => x.PartitionKey == partitionKey.ToString() && x.RowKey == id).AsTableQuery();
             var results = await q.ExecuteSegmentedAsync(null);
             return results.FirstOrDefault();
         }
@@ -89,6 +128,7 @@ namespace Edubase.Data.Repositories
             {
                 item.RowKey = Guid.NewGuid().ToString("N").Substring(0, 8);
             }
+
             await CreateAsync(item);
 
 
@@ -113,6 +153,5 @@ namespace Edubase.Data.Repositories
             item.Version++;
             await Table.ExecuteAsync(TableOperation.Replace(item));
         }
-
     }
 }

--- a/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
+++ b/Web/Edubase.Data/Repositories/NotificationBannerRepository.cs
@@ -77,7 +77,6 @@ namespace Edubase.Data.Repositories
                                 && x.End >= DateTime.Now)
                     .Take(2).AsTableQuery();
             var notificationBanners = Table.ExecuteQuery(query).ToList();
-            Console.WriteLine("current thread is background: " + Thread.CurrentThread.IsBackground);
 
             //the cache only adds values if they don't exist - the method name doesn't make this clear.
             cache.Add(TopTwoNotificationBannersCacheKey,

--- a/Web/Edubase.Web.UI/Controllers/NotificationsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/NotificationsController.cs
@@ -401,7 +401,8 @@ namespace Edubase.Web.UI.Controllers
         [Route("BannersPartial")]
         public ActionResult BannersPartial()
         {
-            var notificationBanners = _BannerRepository.GetTopTwoCurrentNotificationBanners();
+            var notificationBanners =
+                _BannerRepository.GetNotificationBanners(2);
             var model = new NotificationsBannersViewModel(notificationBanners);
             return PartialView("_NotificationsBannersPartial", model);
         }

--- a/Web/Edubase.Web.UI/Controllers/NotificationsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/NotificationsController.cs
@@ -13,11 +13,12 @@ using Edubase.Web.UI.Models.Notifications;
 
 namespace Edubase.Web.UI.Controllers
 {
-    [RoutePrefix("Notifications"), Route("{action=index}")]
+    [RoutePrefix("Notifications")]
+    [Route("{action=index}")]
     public class NotificationsController : EduBaseController
     {
-        private readonly NotificationTemplateRepository _TemplateRepository;
         private readonly NotificationBannerRepository _BannerRepository;
+        private readonly NotificationTemplateRepository _TemplateRepository;
 
         public NotificationsController(
             NotificationTemplateRepository TemplateRepository,
@@ -27,13 +28,15 @@ namespace Edubase.Web.UI.Controllers
             _BannerRepository = BannerRepository;
         }
 
-        [Route(Name = "Notifications"), EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route(Name = "Notifications")]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public ActionResult Index()
         {
             return View();
         }
 
-        [Route("Banners"), EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banners")]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> Banners()
         {
             var result = await _BannerRepository.GetAllAsync(2, null, true);
@@ -44,10 +47,12 @@ namespace Edubase.Web.UI.Controllers
                 ViewBag.ShowSaved = true;
                 TempData.Remove("ShowSaved");
             }
+
             return View(model);
         }
 
-        [Route("Banners/Audit"), EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banners/Audit")]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> AuditBanners(string sortBy)
         {
             var result = await _BannerRepository.GetAllAsync(1000);
@@ -63,7 +68,8 @@ namespace Edubase.Web.UI.Controllers
             return View(model);
         }
 
-        [Route("Banners/Audit/{id}"), EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banners/Audit/{id}")]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> AuditBanner(string id, string sortBy)
         {
             var result = await _BannerRepository.GetAllAsync(1000);
@@ -77,7 +83,9 @@ namespace Edubase.Web.UI.Controllers
             return View(model);
         }
 
-        [Route("Banner/New", Name = "CreateBanner"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/New", Name = "CreateBanner")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> CreateBanner()
         {
             var banners = await _BannerRepository.GetAllAsync(1000, null, true);
@@ -88,20 +96,27 @@ namespace Edubase.Web.UI.Controllers
                 Counter = banners.Items.Count() + 1
             };
             return View("EditBanner", newBanner);
-        } 
+        }
 
 
-        [Route("Banner/New", Name = "PostCreateBanner"), HttpPost, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/New", Name = "PostCreateBanner")]
+        [HttpPost]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> CreateBannerAsync(NotificationsBannerViewModel viewModel)
         {
             return await ProcessEditBanner(viewModel);
         }
 
-        [Route("Banner/{counter}/{id}", Name = "EditBanner"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/{counter}/{id}", Name = "EditBanner")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> EditBannerAsync(string id, int counter)
         {
             var item = await _BannerRepository.GetAsync(id);
-            if (item == null) return HttpNotFound();
+            if (item == null)
+            {
+                return HttpNotFound();
+            }
 
             var banners = await _BannerRepository.GetAllAsync(1000, null, true);
 
@@ -111,30 +126,37 @@ namespace Edubase.Web.UI.Controllers
                 TempData.Remove("ShowSaved");
             }
 
-            return View("EditBanner", new NotificationsBannerViewModel
-            {
-                Id = id,
-                Counter = counter,
-                Start = new DateTimeViewModel(item.Start, item.Start),
-                StartOriginal = item.Start,
-                End = new DateTimeViewModel(item.End, item.End),
-                Importance = (eNotificationBannerImportance)item.Importance,
-                Content = item.Content,
-                TotalBanners = banners.Items.Count(),
-                TotalLiveBanners = banners.Items.Count(x => x.Visible)
-            });
+            return View("EditBanner",
+                new NotificationsBannerViewModel
+                {
+                    Id = id,
+                    Counter = counter,
+                    Start = new DateTimeViewModel(item.Start, item.Start),
+                    StartOriginal = item.Start,
+                    End = new DateTimeViewModel(item.End, item.End),
+                    Importance = (eNotificationBannerImportance) item.Importance,
+                    Content = item.Content,
+                    TotalBanners = banners.Items.Count(),
+                    TotalLiveBanners = banners.Items.Count(x => x.Visible)
+                });
         }
 
-        [Route("Banner/{counter}/{id}", Name = "PostEditBanner"), HttpPost, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/{counter}/{id}", Name = "PostEditBanner")]
+        [HttpPost]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> EditBannerAsync(NotificationsBannerViewModel viewModel)
         {
             var item = await _BannerRepository.GetAsync(viewModel.Id);
-            if (item == null) return HttpNotFound();
+            if (item == null)
+            {
+                return HttpNotFound();
+            }
 
             return await ProcessEditBanner(viewModel, item);
         }
 
-        private async Task<ActionResult> ProcessEditBanner(NotificationsBannerViewModel viewModel, NotificationBanner originalBanner = null)
+        private async Task<ActionResult> ProcessEditBanner(NotificationsBannerViewModel viewModel,
+            NotificationBanner originalBanner = null)
         {
             if (viewModel.GoBack)
             {
@@ -149,7 +171,8 @@ namespace Edubase.Web.UI.Controllers
 
             if (ModelState.IsValid)
             {
-                if (viewModel.Action == eNotificationBannerAction.Start || viewModel.Action == eNotificationBannerAction.TypeChoice)
+                if (viewModel.Action == eNotificationBannerAction.Start ||
+                    viewModel.Action == eNotificationBannerAction.TypeChoice)
                 {
                     // populate the templates, we need to do this the usual route through, and also if they have clicked the back button
                     var result = await _TemplateRepository.GetAllAsync(1000);
@@ -185,11 +208,12 @@ namespace Edubase.Web.UI.Controllers
                         item.AuditEvent = eNotificationBannerEvent.Update.ToString();
                         await _BannerRepository.UpdateAsync(item);
                     }
+
                     TempData["ShowSaved"] = true;
 
-                    return viewModel.Counter == 0 ?
-                        RedirectToAction(nameof(EditBannerAsync), new {counter = 0, id = viewModel.Id}) :
-                        RedirectToAction(nameof(Banners));
+                    return viewModel.Counter == 0
+                        ? RedirectToAction(nameof(EditBannerAsync), new { counter = 0, id = viewModel.Id })
+                        : RedirectToAction(nameof(Banners));
                 }
 
                 ModelState.Remove(nameof(viewModel.Action));
@@ -203,15 +227,23 @@ namespace Edubase.Web.UI.Controllers
         }
 
 
-        [Route("Banner/{counter}/{id}/Delete", Name = "DeleteBanner"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/{counter}/{id}/Delete", Name = "DeleteBanner")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> DeleteBannerAsync(NotificationsBannerViewModel viewModel)
         {
             var item = await _BannerRepository.GetAsync(viewModel.Id);
-            if (item == null) return HttpNotFound();
+            if (item == null)
+            {
+                return HttpNotFound();
+            }
+
             return View("ConfirmDeleteBanner", viewModel.Set(item));
         }
 
-        [Route("Banner/{counter}/{id}/Delete/Confirm", Name = "DeleteBannerConfirmed"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Banner/{counter}/{id}/Delete/Confirm", Name = "DeleteBannerConfirmed")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> DeleteBannerConfirmedAsync(NotificationsBannerViewModel viewModel)
         {
             var item = await _BannerRepository.GetAsync(viewModel.Id);
@@ -226,9 +258,8 @@ namespace Edubase.Web.UI.Controllers
         }
 
 
-
-
-        [Route("Templates"), EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Templates")]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> Templates()
         {
             var result = await _TemplateRepository.GetAllAsync(1000);
@@ -240,35 +271,46 @@ namespace Edubase.Web.UI.Controllers
                 ViewBag.ShowSaved = true;
                 TempData.Remove("ShowSaved");
             }
+
             return View(model);
         }
 
-        [Route("Template/New", Name = "CreateTemplate"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
-        public ActionResult CreateTemplate() => View("EditTemplate", new NotificationsTemplateViewModel());
+        [Route("Template/New", Name = "CreateTemplate")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        public ActionResult CreateTemplate()
+        {
+            return View("EditTemplate", new NotificationsTemplateViewModel());
+        }
 
 
-        [Route("Template/New", Name = "PostCreateTemplate"), HttpPost, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Template/New", Name = "PostCreateTemplate")]
+        [HttpPost]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> CreateTemplateAsync(NotificationsTemplateViewModel viewModel)
         {
             return await ProcessEditTemplate(viewModel);
         }
 
 
-        [Route("Template/{id}", Name= "EditTemplate"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Template/{id}", Name = "EditTemplate")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> EditTemplateAsync(string id)
         {
             var item = await _TemplateRepository.GetAsync(id);
-            if (item == null) return HttpNotFound();
-
-            return View("EditTemplate", new NotificationsTemplateViewModel
+            if (item == null)
             {
-                Id = id,
-                Content = item.Content,
-                OriginalContent = item.Content
-            });
+                return HttpNotFound();
+            }
+
+            return View("EditTemplate",
+                new NotificationsTemplateViewModel { Id = id, Content = item.Content, OriginalContent = item.Content });
         }
 
-        [Route("Template/{id}", Name = "PostEditTemplate"), HttpPost, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Template/{id}", Name = "PostEditTemplate")]
+        [HttpPost]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> EditTemplateAsync(NotificationsTemplateViewModel viewModel)
         {
             var item = await _TemplateRepository.GetAsync(viewModel.Id);
@@ -280,7 +322,8 @@ namespace Edubase.Web.UI.Controllers
             return await ProcessEditTemplate(viewModel, item);
         }
 
-        private async Task<ActionResult> ProcessEditTemplate(NotificationsTemplateViewModel viewModel, NotificationTemplate oldModel = null)
+        private async Task<ActionResult> ProcessEditTemplate(NotificationsTemplateViewModel viewModel,
+            NotificationTemplate oldModel = null)
         {
             if (viewModel.GoBack)
             {
@@ -299,10 +342,7 @@ namespace Edubase.Web.UI.Controllers
                 {
                     if (string.IsNullOrEmpty(viewModel.Id))
                     {
-                        var item = new NotificationTemplate()
-                        {
-                            Content = viewModel.Content,
-                        };
+                        var item = new NotificationTemplate { Content = viewModel.Content };
                         await _TemplateRepository.CreateAsync(item);
                     }
                     else
@@ -311,6 +351,7 @@ namespace Edubase.Web.UI.Controllers
                         item.Content = viewModel.Content;
                         await _TemplateRepository.UpdateAsync(item);
                     }
+
                     TempData["ShowSaved"] = true;
                     return RedirectToAction(nameof(Templates));
                 }
@@ -326,7 +367,9 @@ namespace Edubase.Web.UI.Controllers
         }
 
 
-        [Route("Template/{id}/Delete", Name = "DeleteTemplate"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+        [Route("Template/{id}/Delete", Name = "DeleteTemplate")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> DeleteTemplateAsync(NotificationsTemplateViewModel viewModel)
         {
             var item = await _TemplateRepository.GetAsync(viewModel.Id);
@@ -334,10 +377,14 @@ namespace Edubase.Web.UI.Controllers
             {
                 return HttpNotFound();
             }
-            return View("ConfirmDeleteTemplate", new NotificationsTemplateViewModel {Id = item.RowKey, Content = item.Content});
+
+            return View("ConfirmDeleteTemplate",
+                new NotificationsTemplateViewModel { Id = item.RowKey, Content = item.Content });
         }
-        
-        [Route("Template/{id}/Delete/Confirm", Name = "DeleteTemplateConfirmed"), HttpGet, EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
+
+        [Route("Template/{id}/Delete/Confirm", Name = "DeleteTemplateConfirmed")]
+        [HttpGet]
+        [EdubaseAuthorize(Roles = AuthorizedRoles.IsAdmin)]
         public async Task<ActionResult> DeleteTemplateConfirmedAsync(NotificationsTemplateViewModel viewModel)
         {
             var item = await _TemplateRepository.GetAsync(viewModel.Id);
@@ -351,12 +398,11 @@ namespace Edubase.Web.UI.Controllers
             return RedirectToAction(nameof(Templates));
         }
 
-
         [Route("BannersPartial")]
         public ActionResult BannersPartial()
         {
-            var visible = _BannerRepository.GetAll(2);
-            var model = new NotificationsBannersViewModel(visible.Items);
+            var notificationBanners = _BannerRepository.GetTopTwoCurrentNotificationBanners();
+            var model = new NotificationsBannersViewModel(notificationBanners);
             return PartialView("_NotificationsBannersPartial", model);
         }
     }

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -330,7 +330,7 @@
       The cache is used to reduce how often the table storage is hit
       As each request requires a load of the notifiaction banners
     -->
-    <add key="NotificationBannerCacheExpirationInMinutes" value="5"/>
+    <add key="NotificationBannerCacheExpirationInSeconds" value="300"/>
 
   </appSettings>
 

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -325,6 +325,11 @@
     <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/"/>
     <add key="SASimulatorGuid" value=""/>
 
+    <!--
+      NotificationBannerCacheExpirationInMinutes sets how long before the cache for notification banners expires
+      The cache is used to reduce how often the table storage is hit
+      As each request requires a load of the notifiaction banners
+    -->
     <add key="NotificationBannerCacheExpirationInMinutes" value="5"/>
 
   </appSettings>

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -13,12 +13,14 @@
       For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
       or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you.
     -->
-    <section name="glimpse" type="Glimpse.Core.Configuration.Section, Glimpse.Core" />
+    <section name="glimpse" type="Glimpse.Core.Configuration.Section, Glimpse.Core"/>
 
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <section name="entityFramework"
+             type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+             requirePermission="false"/>
 
-    <section name="httpAuthModule" type="System.Configuration.NameValueFileSectionHandler" />
+    <section name="httpAuthModule" type="System.Configuration.NameValueFileSectionHandler"/>
   </configSections>
 
   <connectionStrings>
@@ -30,7 +32,7 @@
       Note that the API typically uses a different Azure Storage account
       to serve e.g., pre-generated extracts/downloads.
     -->
-    <add name="DataConnectionString" connectionString="" />
+    <add name="DataConnectionString" connectionString=""/>
 
     <!--
       The GIAS website makes (limited) use of Redis caches to minimise the number of API requests made.
@@ -38,7 +40,7 @@
 
       GIAS's caching strategy is for review, and this may be removed at a later date.
     -->
-    <add name="Redis" connectionString="" />
+    <add name="Redis" connectionString=""/>
   </connectionStrings>
   <appSettings>
 
@@ -47,13 +49,13 @@
       The 'Environment` setting is used as a descriptor for the environment in which the application is running.
       - When running locally, this value should be set to 'localdev' (some local-specific options rely on this).
     -->
-    <add key="Environment" value="localdev" />
+    <add key="Environment" value="localdev"/>
 
     <!--
       TBC, Potentially unused, replaced by filter and `EnableFriendlyErrorPage`(?)
       See also: Edubase.Web.UI.MvcApplication.Application_Error
     -->
-    <add key="EnableErrorReporting" value="true" />
+    <add key="EnableErrorReporting" value="true"/>
 
     <!--
       A "friendly" error page is one which hides the technical detail / stack trace.
@@ -64,19 +66,19 @@
 
       See also: Edubase.Web.UI.Filters.ExceptionHandler.OnException
     -->
-    <add key="EnableFriendlyErrorPage" value="true" />
+    <add key="EnableFriendlyErrorPage" value="true"/>
 
     <!--
       Razor engine version (e.g., MVC3 users Razor v3)
 
       See also: https://devblogs.microsoft.com/dotnet/how-does-vs-determine-which-version-of-razor-engine-to-use-when-editing-razor-webpage-files.aspx
     -->
-    <add key="webpages:Version" value="3.0.0.0" />
+    <add key="webpages:Version" value="3.0.0.0"/>
 
     <!--
       Setting `webpages:Enabled` to `false` prevents direct access of e.g., `.cshtml` files
     -->
-    <add key="webpages:Enabled" value="false" />
+    <add key="webpages:Enabled" value="false"/>
 
     <!--
       Where GIAS is accessed via a proxy (e.g., Azure Front Door), the header `X-Forwarded-Host`
@@ -110,7 +112,7 @@
     <!--
       TBC - Used by Glimpse? (debugging tool)
     -->
-    <add key="ApiTraceSessionRetentionCount" value="25" />
+    <add key="ApiTraceSessionRetentionCount" value="25"/>
 
     <!--
       Debugging utility to inspect routes available and routes potentially matching the current page
@@ -119,7 +121,7 @@
 
       See also: https://haacked.com/archive/2008/03/13/url-routing-debugger.aspx/
     -->
-    <add key="RouteDebugger:Enabled" value="false" />
+    <add key="RouteDebugger:Enabled" value="false"/>
 
     <!--
       API Logging records the HTTP requests and responses made to the API.
@@ -135,7 +137,7 @@
       If this is enabled in production-like environment, access to the log data
       *must* be monitored, and the data must be removed as soon as reasonably practical.
     -->
-    <add key="EnableApiLogging" value="false" />
+    <add key="EnableApiLogging" value="false"/>
 
 
     <!-- ==== GIAS WEBSITE FUNCTIONALITY CONFIGURATION ==== -->
@@ -143,7 +145,7 @@
       This is the maximum permitted age (in days) of a data quality check,
       before users will be prompted again.
     -->
-    <add key="DataQualityUpdatePeriod" value="7" />
+    <add key="DataQualityUpdatePeriod" value="7"/>
 
     <!--
       Sitemaps are accessed by e.g., search engine bots to index the website.
@@ -154,12 +156,13 @@
 
       See also: Edubase.Web.UI.Controllers.SitemapController.ExcludeApiLookup
     -->
-    <add key="SitemapCacheDays" value="21" />
-    <add key="SitemapExcludeApi" value="0" />
+    <add key="SitemapCacheDays" value="21"/>
+    <add key="SitemapExcludeApi" value="0"/>
 
 
     <!-- ====  ==== -->
-    <add key="Content-Security-Policy" value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://www.find-school-performance-data.service.gov.uk/; frame-src https://www.googletagmanager.com; img-src 'self' data: https://*.google-analytics.com https://*.analytics.google.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://code.jquery.com http://d3js.org;" />
+    <add key="Content-Security-Policy"
+         value="base-uri 'self'; object-src 'none'; default-src 'self'; frame-ancestors 'none'; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://www.find-school-performance-data.service.gov.uk/; frame-src https://www.googletagmanager.com; img-src 'self' data: https://*.google-analytics.com https://*.analytics.google.com https://atlas.microsoft.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'nonce-inject' 'unsafe-eval' https://www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://code.jquery.com http://d3js.org;"/>
 
 
     <!-- ==== JAVASCRIPT API KEYS ==== -->
@@ -170,15 +173,15 @@
       - `AzureMapsApiKey`           Maps are displayed on the search results and some establishment detail pages
       - `OSPlacesApiKey`            Auto-complete functionality on Azure Maps (TBC)
     -->
-    <add key="GoogleApiKeyClientSide" value="" />
-    <add key="GoogleTagManagerKey" value="" />
-    <add key="AzureMapsApiKey" value="" />
-    <add key="OSPlacesApiKey" value="" />
+    <add key="GoogleApiKeyClientSide" value=""/>
+    <add key="GoogleTagManagerKey" value=""/>
+    <add key="AzureMapsApiKey" value=""/>
+    <add key="OSPlacesApiKey" value=""/>
 
     <!-- TBC -->
-    <add key="ClientValidationEnabled" value="false" />
+    <add key="ClientValidationEnabled" value="false"/>
     <!-- TBC -->
-    <add key="UnobtrusiveJavaScriptEnabled" value="false" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="false"/>
 
 
     <!-- ==== GIAS API DEPENDENCIES ==== -->
@@ -188,13 +191,13 @@
       Note: Do not supply username/password (or other secrets) directly here.
       Specify this via app config on Azure, or via dev secrets if running locally.
     -->
-    <add key="TexunaApiBaseAddress" value="" />
-    <add key="api:Username" value="rest-api-user" />
-    <add key="api:Password" value="" />
+    <add key="TexunaApiBaseAddress" value=""/>
+    <add key="api:Username" value="rest-api-user"/>
+    <add key="api:Password" value=""/>
 
-    <add key="LookupApiBaseAddress" value="" />
-    <add key="LookupApiUsername" value="rest-api-user" />
-    <add key="LookupApiPassword" value="" />
+    <add key="LookupApiBaseAddress" value=""/>
+    <add key="LookupApiUsername" value="rest-api-user"/>
+    <add key="LookupApiPassword" value=""/>
 
 
     <!-- ==== 3RD PARTY API DEPENDENCIES ==== -->
@@ -202,8 +205,8 @@
       Academies are registered businesses, and some information about those businesses are made visible within GIAS.
       Companies House supply those business/company details via the API.
     -->
-    <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/" />
-    <add key="CompaniesHouseApiKey" value="" />
+    <add key="CompaniesHouseBaseUrl" value="https://beta.companieshouse.gov.uk/company/"/>
+    <add key="CompaniesHouseApiKey" value=""/>
 
     <!--
       The Schools Financial Benchmarking (SFB) service provides data
@@ -224,11 +227,11 @@
 
       See also: https://schools-financial-benchmarking.service.gov.uk/
     -->
-    <add key="FinancialBenchmarkingURL" value="https://as-t1dv-sfb.azurewebsites.net/" />
-    <add key="FinancialBenchmarkingApiURL" value="https://aa-t1dv-sfb.azurewebsites.net/" />
-    <add key="FinancialBenchmarkingCacheHours" value="72" />
-    <add key="FinancialBenchmarkingUsername" value="" />
-    <add key="FinancialBenchmarkingPassword" value="" />
+    <add key="FinancialBenchmarkingURL" value="https://as-t1dv-sfb.azurewebsites.net/"/>
+    <add key="FinancialBenchmarkingApiURL" value="https://aa-t1dv-sfb.azurewebsites.net/"/>
+    <add key="FinancialBenchmarkingCacheHours" value="72"/>
+    <add key="FinancialBenchmarkingUsername" value=""/>
+    <add key="FinancialBenchmarkingPassword" value=""/>
 
     <!--
       The Find School and College Performance Data (FSCPD) service provides data
@@ -250,12 +253,12 @@
       - `FscpdUsername`     (Not normally supplied) Basic auth username to access the FSCPD service.
       - `FscpdPassword`     (Not normally supplied) Basic auth username to access the FSCPD service.
     -->
-    <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables" />
-    <add key="FscpdURL" value="https://www.compare-school-performance.service.gov.uk/" />
-    <add key="FscpdServiceName" value="Compare school and college performance in England" />
-    <add key="FscpdCacheHours" value="72" />
-    <add key="FscpdUsername" value="" />
-    <add key="FscpdPassword" value="" />
+    <add key="FscpdHomeUrl" value="https://www.gov.uk/school-performance-tables"/>
+    <add key="FscpdURL" value="https://www.compare-school-performance.service.gov.uk/"/>
+    <add key="FscpdServiceName" value="Compare school and college performance in England"/>
+    <add key="FscpdCacheHours" value="72"/>
+    <add key="FscpdUsername" value=""/>
+    <add key="FscpdPassword" value=""/>
 
 
     <!-- ==== WEBSITE AUTHENTICATION / AUTHORISATION ==== -->
@@ -268,11 +271,11 @@
 
       See also: the <httpAuthModule> section below, within the file `Web.config`.
   -->
-    <add key="HttpAuthModuleEnabled" value="true" />
-    <add key="HttpAuthModule.AuthMode" value="Basic" />
-    <add key="HttpAuthModule.Realm" value="Edubase" />
-<!-- <add key="HttpAuthModule.Credentials" value="" /> -->
-    <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1" />
+    <add key="HttpAuthModuleEnabled" value="true"/>
+    <add key="HttpAuthModule.AuthMode" value="Basic"/>
+    <add key="HttpAuthModule.Realm" value="Edubase"/>
+    <!-- <add key="HttpAuthModule.Credentials" value="" /> -->
+    <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1"/>
 
     <!--
       ACCESS TO INTERACT WITH DATA HELD BY GIAS
@@ -286,7 +289,7 @@
       - `SecureAccessConfiguration`   Use of DSI
       - `SASimulatorConfiguration`    Use of the DSI Simualator
     -->
-    <add key="owin:appStartup" value="SASimulatorConfiguration" />
+    <add key="owin:appStartup" value="SASimulatorConfiguration"/>
 
     <!--
       SA/DSI configuration
@@ -302,10 +305,10 @@
                                           Omitting this setting will default to using the value provided by `request.ApplicationUrl`.
                                           See also #157607 and #171878.
     -->
-    <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase" />
-    <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback" />
-    <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata" />
-    <add key="SessionExpireTimeSpan" value="00:59:00" />
+    <add key="ApplicationIdpEntityId" value="https://stg.education.gov.uk/edubase"/>
+    <add key="ExternalAuthDefaultCallbackUrl" value="http://localhost:51350/Account/ExternalLoginCallback"/>
+    <add key="MetadataLocation" value="https://pp-gias.signin.education.gov.uk/saml/metadata"/>
+    <add key="SessionExpireTimeSpan" value="00:59:00"/>
     <!-- <add key="PublicOrigin" value="" /> -->
 
     <!--
@@ -319,8 +322,10 @@
       - It can be managed via the url `{SASimulatorUri}{SASimulatorGuid}/Manage`
         - e.g., https://dfe-sign-in-simulator.azurewebsites.net/{GUID-123-abc}/Manage
     -->
-    <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/" />
-    <add key="SASimulatorGuid" value="" />
+    <add key="SASimulatorUri" value="https://dfe-sign-in-simulator.azurewebsites.net/"/>
+    <add key="SASimulatorGuid" value=""/>
+
+    <add key="NotificationBannerCacheExpirationInMinutes" value="5"/>
 
   </appSettings>
 
@@ -329,293 +334,324 @@
       <proxy bypassonlocal="False" usesystemdefault="True" proxyaddress="http://127.0.0.1:8888" />
     </defaultProxy>
   </system.net>-->
-    <!--
-    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+  <!--
+  For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
-    The following attributes can be set on the <httpRuntime> tag.
-      <system.Web>
-        <httpRuntime targetFramework="4.7.2" />
-      </system.Web>
-  -->
-    <system.web>
-        <compilation debug="true" targetFramework="4.8" />
-        <httpRuntime targetFramework="4.8" maxQueryStringLength="32000" maxUrlLength="32000" maxRequestLength="102400"
-                     executionTimeout="2097151" enableVersionHeader="false" />
-        <customErrors mode="RemoteOnly" redirectMode="ResponseRewrite" defaultRedirect="~/500.aspx">
-            <error statusCode="403" redirect="~/403.aspx" />
-            <error statusCode="404" redirect="~/404.aspx" />
-            <error statusCode="500" redirect="~/500.aspx" />
-        </customErrors>
-        <!-- Glimpse: This can be commented in to add additional data to the Trace tab when using WebForms
-        <trace writeToDiagnosticsTrace="true" enabled="true" pageOutput="false"/> -->
+  The following attributes can be set on the <httpRuntime> tag.
+    <system.Web>
+      <httpRuntime targetFramework="4.7.2" />
+    </system.Web>
+-->
+  <system.web>
+    <compilation debug="true" targetFramework="4.8"/>
+    <httpRuntime targetFramework="4.8" maxQueryStringLength="32000" maxUrlLength="32000" maxRequestLength="102400"
+                 executionTimeout="2097151" enableVersionHeader="false"/>
+    <customErrors mode="RemoteOnly" redirectMode="ResponseRewrite" defaultRedirect="~/500.aspx">
+      <error statusCode="403" redirect="~/403.aspx"/>
+      <error statusCode="404" redirect="~/404.aspx"/>
+      <error statusCode="500" redirect="~/500.aspx"/>
+    </customErrors>
+    <!-- Glimpse: This can be commented in to add additional data to the Trace tab when using WebForms
+    <trace writeToDiagnosticsTrace="true" enabled="true" pageOutput="false"/> -->
     <httpModules>
-      <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet" />
-      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
+      <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet"/>
+      <add name="TelemetryCorrelationHttpModule"
+           type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"/>
+      <add name="ApplicationInsightsWebTracking"
+           type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"/>
     </httpModules>
     <httpHandlers>
-      <add path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet" />
+      <add path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet"/>
     </httpHandlers>
-    <httpCookies httpOnlyCookies="true" requireSSL="true" />
+    <httpCookies httpOnlyCookies="true" requireSSL="true"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0" />
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.5.0" newVersion="5.8.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.Enterprise.AspNetHelper" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <codeBase version="14.0.0.0" href="file:///C:/Program%20Files%20(x86)/Microsoft%20Visual%20Studio%2014.0/Common7/IDE/PrivateAssemblies/Microsoft.VisualStudio.Enterprise.AspNetHelper.DLL" />
+        <assemblyIdentity name="Microsoft.VisualStudio.Enterprise.AspNetHelper" publicKeyToken="b03f5f7f11d50a3a"
+                          culture="neutral"/>
+        <codeBase version="14.0.0.0"
+                  href="file:///C:/Program%20Files%20(x86)/Microsoft%20Visual%20Studio%2014.0/Common7/IDE/PrivateAssemblies/Microsoft.VisualStudio.Enterprise.AspNetHelper.DLL"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="MiniProfiler" publicKeyToken="b44f9351044011a3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.2.0.157" newVersion="3.2.0.157" />
+        <assemblyIdentity name="MiniProfiler" publicKeyToken="b44f9351044011a3" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.2.0.157" newVersion="3.2.0.157"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.4.0.0" newVersion="6.4.0.0" />
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.4.0.0" newVersion="6.4.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.1.0.0" newVersion="9.1.0.0" />
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-9.1.0.0" newVersion="9.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0" />
+        <assemblyIdentity name="Microsoft.Azure.KeyVault.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.5.0" newVersion="3.0.5.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens.Saml" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens.Saml" publicKeyToken="31bf3856ad364e35"
+                          culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Xml" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Xml" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.22.1.0" newVersion="6.22.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"
+                          culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a"
+                          culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.3" newVersion="6.0.0.3" />
+        <assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.3" newVersion="6.0.0.3"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.9.0" newVersion="5.2.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Threading.Channels" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="mssqllocaldb" />
+        <parameter value="mssqllocaldb"/>
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SqlClient"
+                type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
     </providers>
   </entityFramework>
   <system.serviceModel>
     <extensions>
       <behaviorExtensions>
-        <add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="connectionStatusBehavior"
+             type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="transportClientEndpointBehavior"
+             type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="serviceRegistrySettings"
+             type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
       </behaviorExtensions>
       <bindingElementExtensions>
-        <add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netMessagingTransport"
+             type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="tcpRelayTransport"
+             type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="httpRelayTransport"
+             type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="httpsRelayTransport"
+             type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="onewayRelayTransport"
+             type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
       </bindingElementExtensions>
       <bindingExtensions>
-        <add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        <add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="basicHttpRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="webHttpRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="ws2007HttpRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netTcpRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netOnewayRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netEventRelayBinding"
+             type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netMessagingBinding"
+             type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
       </bindingExtensions>
     </extensions>
   </system.serviceModel>
   <system.webServer>
     <handlers>
-      <add name="SitemapXml" path="sitemap*.xml" verb="GET" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-      <add name="ServiceWSDLHandler" path="service.wsdl" verb="GET" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-      <add name="Glimpse" path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet" preCondition="integratedMode" />
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <add name="SitemapXml" path="sitemap*.xml" verb="GET" type="System.Web.Handlers.TransferRequestHandler"
+           preCondition="integratedMode,runtimeVersionv4.0"/>
+      <add name="ServiceWSDLHandler" path="service.wsdl" verb="GET" type="System.Web.Handlers.TransferRequestHandler"
+           preCondition="integratedMode,runtimeVersionv4.0"/>
+      <add name="Glimpse" path="glimpse.axd" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet"
+           preCondition="integratedMode"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*"
+           type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
     <modules>
-      <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet" preCondition="integratedMode" />
-      <add type="HttpAuthModule.HttpAuthModule" name="HttpAuthModule" />
-      <remove name="TelemetryCorrelationHttpModule" />
-      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" />
-      <remove name="ApplicationInsightsWebTracking" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
+      <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet" preCondition="integratedMode"/>
+      <add type="HttpAuthModule.HttpAuthModule" name="HttpAuthModule"/>
+      <remove name="TelemetryCorrelationHttpModule"/>
+      <add name="TelemetryCorrelationHttpModule"
+           type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
+           preCondition="managedHandler"/>
+      <remove name="ApplicationInsightsWebTracking"/>
+      <add name="ApplicationInsightsWebTracking"
+           type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"
+           preCondition="managedHandler"/>
     </modules>
     <security>
       <requestFiltering removeServerHeader="true">
-        <requestLimits maxQueryString="32000" maxAllowedContentLength="104857600" maxUrl="32000" />
+        <requestLimits maxQueryString="32000" maxAllowedContentLength="104857600" maxUrl="32000"/>
         <fileExtensions>
-          <add fileExtension=".woff2" allowed="true" />
+          <add fileExtension=".woff2" allowed="true"/>
         </fileExtensions>
       </requestFiltering>
     </security>
     <rewrite>
-      <rules />
+      <rules/>
     </rewrite>
     <httpErrors errorMode="Custom">
-      <remove statusCode="404" />
-      <error statusCode="404" path="404.html" responseMode="File" />
-      <remove statusCode="403" />
-      <error statusCode="403" path="403.html" responseMode="File" />
-      <remove statusCode="500" />
-      <error statusCode="500" path="500.html" responseMode="File" />
+      <remove statusCode="404"/>
+      <error statusCode="404" path="404.html" responseMode="File"/>
+      <remove statusCode="403"/>
+      <error statusCode="403" path="403.html" responseMode="File"/>
+      <remove statusCode="500"/>
+      <error statusCode="500" path="500.html" responseMode="File"/>
     </httpErrors>
     <httpProtocol>
       <customHeaders>
-        <remove name="X-Powered-By" />
-        <add name="Cache-Control" value="no-store" />
-        <add name="Pragma" value="no-cache" />
-        <add name="X-Frame-Options" value="DENY" />
-        <add name="X-XSS-Protection" value="0" />
-        <add name="X-Content-Type-Options" value="nosniff" />
+        <remove name="X-Powered-By"/>
+        <add name="Cache-Control" value="no-store"/>
+        <add name="Pragma" value="no-cache"/>
+        <add name="X-Frame-Options" value="DENY"/>
+        <add name="X-XSS-Protection" value="0"/>
+        <add name="X-Content-Type-Options" value="nosniff"/>
       </customHeaders>
     </httpProtocol>
     <staticContent>
-      <remove fileExtension=".woff" />
-      <remove fileExtension=".woff2" />
-      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
-      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+      <remove fileExtension=".woff"/>
+      <remove fileExtension=".woff2"/>
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff"/>
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2"/>
     </staticContent>
-    <validation validateIntegratedModeConfiguration="false" />
+    <validation validateIntegratedModeConfiguration="false"/>
   </system.webServer>
   <glimpse defaultRuntimePolicy="On" endpointBaseUri="~/Glimpse.axd">
     <!--
           For more information on how to configure Glimpse, please visit http://getglimpse.com/Help/Configuration
           or access {your site}/Glimpse.axd for even more details and a Configuration Tool to support you.
       -->
-    </glimpse>
-    <httpAuthModule>
-        <!-- If HttpAuthModule has problems, please contact me, https://github.com/nabehiro/HttpAuthModule -->
-        <!--
-      [required] Http Authentication Mode.
-      - Basic: Basic authentication
-      - Digest: Digest authentication
-      - None: No authentication -->
-    <add key="AuthMode" value="Digest" />
+  </glimpse>
+  <httpAuthModule>
+    <!-- If HttpAuthModule has problems, please contact me, https://github.com/nabehiro/HttpAuthModule -->
+    <!--
+  [required] Http Authentication Mode.
+  - Basic: Basic authentication
+  - Digest: Digest authentication
+  - None: No authentication -->
+    <add key="AuthMode" value="Digest"/>
     <!-- [optional] default is "SecureZone" -->
-    <add key="Realm" value="SecureZone" />
+    <add key="Realm" value="SecureZone"/>
 
     <!--
       Caution - If these credentials are specified here but not explicitly overridden
@@ -625,9 +661,9 @@
     <!-- [required if http auth on] user1:pass1;user2:pass2;... -->
     <!-- <add key="Credentials" value="hoge:hogepass;foo:foopass;" /> -->
     <!-- [optional] Digest Auth Nonce Valid Duration Minutes. default is 120 -->
-    <add key="DigestNonceValidDuration" value="120" />
+    <add key="DigestNonceValidDuration" value="120"/>
     <!-- [required if digest auth on] Digest Auth Nonce Salt -->
-    <add key="DigestNonceSalt" value="uht9987bbbSAX" />
+    <add key="DigestNonceSalt" value="uht9987bbbSAX"/>
     <!--
       [optional] If set, specified IPs are only allowed: otherwize All IPs are allowed.
       value is joined IP Range Combination as following.
@@ -644,20 +680,20 @@
       [optional] If set,specified IPs requests skip http auth Restriction.
       value format is same as 'RestrictIPAddresses'
     -->
-        <!-- <add key="IgnoreIPAddresses" value="127.0.0.1;::1"/> -->
-        <!-- [optional] If set, specified value of Request Header is regarded as Client IP. -->
-        <!-- <add key="ClientIPHeaders" value="CF-CONNECTING-IP;True-Client-IP"/> -->
-        <!-- [optional] If set, specified value of Server Variable is regarded as Client IP. -->
-        <!-- <add key="ClientIPServerVariables" value="HTTP_X_FORWARDED_FOR"/> -->
-    </httpAuthModule>
-    <system.codedom>
-        <compilers>
-            <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4"
-                      compilerOptions="/langversion:7.3 /nowarn:1659;1699;1701;612;618"
-                      type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-            <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4"
-                      compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
-                      type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
-        </compilers>
-    </system.codedom>
+    <!-- <add key="IgnoreIPAddresses" value="127.0.0.1;::1"/> -->
+    <!-- [optional] If set, specified value of Request Header is regarded as Client IP. -->
+    <!-- <add key="ClientIPHeaders" value="CF-CONNECTING-IP;True-Client-IP"/> -->
+    <!-- [optional] If set, specified value of Server Variable is regarded as Client IP. -->
+    <!-- <add key="ClientIPServerVariables" value="HTTP_X_FORWARDED_FOR"/> -->
+  </httpAuthModule>
+  <system.codedom>
+    <compilers>
+      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4"
+                compilerOptions="/langversion:7.3 /nowarn:1659;1699;1701;612;618"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4"
+                compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+    </compilers>
+  </system.codedom>
 </configuration>


### PR DESCRIPTION
Edubase.Data.csproj - 
Automated code cleanup 

NotifiactionBannerRepository.cs -
Automated code cleanup
Constructor modified
 2 new methods
GetNotificationBanners
GetActiveBanners
1 method removed
GetAll

Edit methods to banners clear the in memory cache to force an update on the instance - this wont do anything for other instances.


NotificationController.cs
Automated code cleanup
1 method modified - BannersPartial (last method in the file)

Web.Config
Automated code cleanup
One new setting added - NotificationBannerCacheExpirationInMinutes


Note on unit tests
It pains me to not have a unit test for this, but the NotifiactionBannerRepository inherits from a base class that has concrete dependencies that I cannot replace with Mocks without a lot of refactoring.
For the localised change and the potential of breaking things not already unit tested, I feel it is better to omit unit tests on this change.
