### PR TITLE
Add option to override x-source-ip

### DIFF
--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -108,6 +108,42 @@
     <!-- <add key="AllowedForwardedHostNames" value="example.com,www.example.com"/> -->
 
 
+    <!--
+      Where GIAS is accessed via a proxy (e.g., Azure Front Door / WAF):
+      - The source IP passed via the (custom) `x-source-ip` header to the API
+        is the proxy's IP address, not the user's IP address.
+      - Rate limting of requests to the API is based on this source IP address,
+        therefore all users accessing via the proxy will be subject to the same rate limit.
+
+      As documented within HttpClientWrapper.cs, making GIAS take into account
+      the `x-forwarded-for` header (similar to `x-forwarded-host`) was considered
+      as part of #189483 but the effort to do this correctly (and securely) was
+      deemed too high for the benefit (in the same way that we define the configuration
+      option `AllowedForwardedHostNames` for forwarded host values, a simliar list
+      of known forwarded internal/Azure IP addresses would be required and maintained).
+
+      Note that the `x-forwarded-for` header may be spoofed by users, therefore must not be trusted.
+      (e.g., a user could edit the header with a different value to bypass rate limiting)
+
+      Where a WAF is in place (and providing upstream rate-limiting), this configuration
+      may be used to instruct the API to not rate limit any of these requests as they
+      are originating from the GIAS website (n.b.: the only permitted client for the API).
+
+      Values for `xSourceIpOverride` may be:
+      - Not provided  / an empty string (after trimming) is equivalent to disabling this override
+      - A single IP address (e.g., `192.168.0.1` or any other valid IPv4 address)
+      - An arbitrary string
+        - (max 40 chars per database column width restriction - excess characters are truncated)
+        - Note that the backend API has an option to validate this value.
+        - If wanting to provide a value which does not conform to IPv4 syntax, this validation must be disabled.
+
+      If not provided, or is empty after trimming whitespace, this is treated as not provided and behaviour should
+      continue as previously defined using the client IP address passed to the website.
+    -->
+    <add key="xSourceIpOverride" value="" />
+
+
+
     <!-- ==== GIAS WEBSITE DEBUGGING ==== -->
     <!--
       TBC - Used by Glimpse? (debugging tool)
@@ -291,7 +327,7 @@
     <add key="OSPlacesApiServices_RetryIntervals" value="1,2,2,4"/>
     <add key="AzureMapService_RetryIntervals" value="1,2,2,4"/>
 
-    
+
     <!--
       ACCESS TO INTERACT WITH DATA HELD BY GIAS
 


### PR DESCRIPTION
If not provided or is empty string, defaults to pre-existing behaviour (no change).

See details / screenshots etc. within #189483