### PR TITLE
Governance professional to a SAT

### DIFF
--- a/Web/Edubase.Services/Enums/EnumSets.cs
+++ b/Web/Edubase.Services/Enums/EnumSets.cs
@@ -55,7 +55,8 @@ namespace Edubase.Services.Enums
             GR.GovernanceProfessionalToAMat,
             GR.GovernanceProfessionalToASecureSat,
             GR.Group_SharedGovernanceProfessional,
-            GR.Establishment_SharedGovernanceProfessional
+            GR.Establishment_SharedGovernanceProfessional,
+            GR.GovernanceProfessionalToASat,
         };
 
         public static IEnumerable<int> SingularGovernorRoles { get; } = eSingularGovernorRoles.Cast<int>();

--- a/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
+++ b/Web/Edubase.Services/Enums/eLookupGovernorRole.cs
@@ -29,5 +29,6 @@ namespace Edubase.Services.Enums
         Member_Individual = 21,
         Member_Organisation = 22,
         GovernanceProfessionalToASecureSat = 23,
+        GovernanceProfessionalToASat = 24,
     }
 }

--- a/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
+++ b/Web/Edubase.Services/Governors/Factories/GovernorRoleNameFactory.cs
@@ -31,6 +31,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, "Governance professional to an individual academy or free school" },
             { eLookupGovernorRole.GovernanceProfessionalToAMat, "Governance professional to a MAT" },
             { eLookupGovernorRole.GovernanceProfessionalToASecureSat, "Governance professional to a secure SAT" },
+            { eLookupGovernorRole.GovernanceProfessionalToASat, "Governance professional for a single-academy trust (SAT)" },
         };
 
         private static readonly Dictionary<eLookupGovernorRole, string> PluralisedLabels = new Dictionary<eLookupGovernorRole, string>()
@@ -50,6 +51,7 @@ namespace Edubase.Services.Governors.Factories
             { eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, "Governance professionals to an individual academy or free school" },
             { eLookupGovernorRole.GovernanceProfessionalToAMat, "Governance professionals to a MAT" },
             { eLookupGovernorRole.GovernanceProfessionalToASecureSat, "Governance professionals to a secure SAT" },
+            { eLookupGovernorRole.GovernanceProfessionalToASat, "Governance professionals for a single-academy trust (SAT)" },
         };
 
         public static string Create(eLookupGovernorRole role, eTextCase textCase = eTextCase.SentenceCase, bool pluraliseLabelIfApplicable = false)


### PR DESCRIPTION
This commit prepares the frontend to be able to recognise the new "Governance professional for a single-academy trust (SAT)" role once it is implemented within the backend.

#191487