### PR TITLE
BG/193913_add Shared governance professional to Group/Establishment level

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -477,13 +477,10 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             var isMatPresent = existingGovernorRoleIds.Any(m => m == (int)eLookupGovernorRole.GovernanceProfessionalToAMat);
             var isAddingGroup = role == eLookupGovernorRole.Group_SharedGovernanceProfessional;
             var isAddingMat = role == eLookupGovernorRole.GovernanceProfessionalToAMat;
-            if (!((isAddingMat && isGroupPresent) || (isAddingGroup && isMatPresent)))
+            if (!((isAddingMat && isGroupPresent) || (isAddingGroup && isMatPresent))
+                && IsEquivalentRoleAlreadyPresent(role, EnumSets.eGovernanceProfessionalRoles, existingGovernorRoleIds))
             {
-                // Only a single governance professional may be attached
-                if (IsEquivalentRoleAlreadyPresent(role, EnumSets.eGovernanceProfessionalRoles, existingGovernorRoleIds))
-                {
-                    return false;
-                }
+                return false;
             }
 
             // Where the new governor is a role which permits only a single appointee, forbid if an exact match is found

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -477,7 +477,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             var isMatPresent = existingGovernorRoleIds.Any(m => m == (int)eLookupGovernorRole.GovernanceProfessionalToAMat);
             var isAddingGroup = role == eLookupGovernorRole.Group_SharedGovernanceProfessional;
             var isAddingMat = role == eLookupGovernorRole.GovernanceProfessionalToAMat;
-
             if (!((isAddingMat && isGroupPresent) || (isAddingGroup && isMatPresent)))
             {
                 // Only a single governance professional may be attached

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -472,10 +472,19 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 return false;
             }
 
-            // Only a single governance professional may be attached
-            if (IsEquivalentRoleAlreadyPresent(role, EnumSets.eGovernanceProfessionalRoles, existingGovernorRoleIds))
+            // At MAT level you should be able to have a 'Shared governance professional - group' and a 'Governance professional to a MAT'
+            var isGroupPresent = existingGovernorRoleIds.Any(g => g == (int)eLookupGovernorRole.Group_SharedGovernanceProfessional);
+            var isMatPresent = existingGovernorRoleIds.Any(m => m == (int)eLookupGovernorRole.GovernanceProfessionalToAMat);
+            var isAddingGroup = role == eLookupGovernorRole.Group_SharedGovernanceProfessional;
+            var isAddingMat = role == eLookupGovernorRole.GovernanceProfessionalToAMat;
+
+            if (!((isAddingMat && isGroupPresent) || (isAddingGroup && isMatPresent)))
             {
-                return false;
+                // Only a single governance professional may be attached
+                if (IsEquivalentRoleAlreadyPresent(role, EnumSets.eGovernanceProfessionalRoles, existingGovernorRoleIds))
+                {
+                    return false;
+                }
             }
 
             // Where the new governor is a role which permits only a single appointee, forbid if an exact match is found

--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -477,6 +477,8 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
             var isMatPresent = existingGovernorRoleIds.Any(m => m == (int)eLookupGovernorRole.GovernanceProfessionalToAMat);
             var isAddingGroup = role == eLookupGovernorRole.Group_SharedGovernanceProfessional;
             var isAddingMat = role == eLookupGovernorRole.GovernanceProfessionalToAMat;
+
+            // Unless above condition met, Only a single governance professional may be attached
             if (!((isAddingMat && isGroupPresent) || (isAddingGroup && isMatPresent))
                 && IsEquivalentRoleAlreadyPresent(role, EnumSets.eGovernanceProfessionalRoles, existingGovernorRoleIds))
             {


### PR DESCRIPTION
Correct an error that appears when adding a 'Shared governance professional - group' and a 'Governance professional to a MAT'