### PR TITLE
Bg/192355 Unit tests failing

### DIFF
--- a/Web/Edubase.ServicesUnitTests/ExternalLookup/FBServiceTests.cs
+++ b/Web/Edubase.ServicesUnitTests/ExternalLookup/FBServiceTests.cs
@@ -31,10 +31,10 @@ namespace Edubase.Services.ExternalLookup.UnitTests
         }
 
         [Theory]
-        [InlineData(1, FbType.School, "https://example.com/api/schoolstatus/1", "ApiUrl_ReturnsCorrectUrl_School")]
-        [InlineData(1, FbType.Federation, "https://example.com/api/federationstatus/1", "ApiUrl_ReturnsCorrectUrl_Federation")]
-        [InlineData(1, FbType.Trust, "https://example.com/api/truststatus/1", "ApiUrl_ReturnsCorrectUrl_Trust")]
-        public void ApiUrl_ReturnsCorrectUrl(int? lookupId, FbType lookupType, string expectedUrl, string testName)
+        [InlineData(1, FbType.School, "https://example.com/api/schoolstatus/1")]
+        [InlineData(1, FbType.Federation, "https://example.com/api/federationstatus/1")]
+        [InlineData(1, FbType.Trust, "https://example.com/api/truststatus/1")]
+        public void ApiUrl_ReturnsCorrectUrl(int? lookupId, FbType lookupType, string expectedUrl)
         {
             ConfigurationManager.AppSettings["FinancialBenchmarkingApiURL"] = "https://example.com/";
             var client = new HttpClient();

--- a/Web/Edubase.ServicesUnitTests/ExternalLookup/FBServiceTests.cs
+++ b/Web/Edubase.ServicesUnitTests/ExternalLookup/FBServiceTests.cs
@@ -36,8 +36,9 @@ namespace Edubase.Services.ExternalLookup.UnitTests
         [InlineData(1, FbType.Trust, "https://example.com/api/truststatus/1", "ApiUrl_ReturnsCorrectUrl_Trust")]
         public void ApiUrl_ReturnsCorrectUrl(int? lookupId, FbType lookupType, string expectedUrl, string testName)
         {
-            _output.WriteLine(testName);
-            var subject = new FBService(new HttpClient());
+            ConfigurationManager.AppSettings["FinancialBenchmarkingApiURL"] = "https://example.com/";
+            var client = new HttpClient();
+            var subject = new FBService(client);
             var apiUrl = subject.ApiUrl(lookupId, lookupType);
             Assert.Equal(expectedUrl, apiUrl);
         }

--- a/Web/Edubase.ServicesUnitTests/IntegrationEndPoints/PollyUtilTests.cs
+++ b/Web/Edubase.ServicesUnitTests/IntegrationEndPoints/PollyUtilTests.cs
@@ -40,28 +40,23 @@ namespace Edubase.ServicesUnitTests.IntegrationEndPoints
         }
 
         //Note: Polly doesn't expose the timeout settings once the policy is created
-        // TODO: Ticket is being created to look at this test, commented out as causing issues in pipeline
-        //[Fact]
-        //public async void CreateTimeoutPolicy_ReturnsCorrectTimeoutForAzureMapService()
-        //{
-        //    var validKey = "AzureMapService_Timeout";
-        //    ConfigurationManager.AppSettings[validKey] = "5";
+        //Note: Due to pipeline issues we are not measuring with precise timing, but asserting on the occurence of 'TimeoutRejectedException'
+        [Fact]
+        public async Task CreateTimeoutPolicy_ShouldTriggerTimeout()
+        {
+            var validKey = "AzureMapService_Timeout";
+            ConfigurationManager.AppSettings[validKey] = "5";
 
-        //    var policy = PollyUtil.CreateTimeoutPolicy(validKey);
+            var policy = PollyUtil.CreateTimeoutPolicy(validKey);
 
-        //    var sw = Stopwatch.StartNew();
-        //    await Assert.ThrowsAsync<TimeoutRejectedException>(async () =>
-        //    {
-        //        await policy.ExecuteAsync(async (ct) =>
-        //        {
-        //            await Task.Delay(6000, ct);
-        //        }, CancellationToken.None);
-        //    });
-        //    sw.Stop();
+            Func<CancellationToken, Task> operation = async (ct) =>
+            {
+                await Task.Delay(6000, ct);
+            };
 
-        //    Assert.NotNull(policy);
-        //    Assert.True(sw.Elapsed.Seconds >= 5 && sw.Elapsed.Seconds < 8, $"Timeout expected Elapsed >= 5 && Elapsed < 8 Actual: {sw.Elapsed.Seconds}");
-        //}
+            await Assert.ThrowsAsync<TimeoutRejectedException>(() => policy.ExecuteAsync(operation, CancellationToken.None));
+            Assert.NotNull(policy);
+        }
 
 
         [Fact]


### PR DESCRIPTION
Unit tests that are passing locally but then failing in the pipeline

1. PolyUtil - focus on directly testing timeout for a 'TimeoutRejectedException'
2. FBService - ensure configured correctly regardless of environmental variables