### PR TITLE
Bugfix, where the edit form now honours the API-provided selected value.

### DIFF
--- a/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
+++ b/Web/Edubase.Web.UI/Helpers/HtmlHelperExtensions.cs
@@ -283,7 +283,15 @@ namespace Edubase.Web.UI.Helpers
 
             foreach (var item in selectListItem)
             {
-                options = options.Append("<option value='" + item.Value + "'id='" + expressionText + "-option-" + item.Text + "'>" + item.Text + "</option>");
+                options = options.Append(
+                    "<option " +
+                    " value='" + item.Value + "'" +
+                    " id='" + expressionText + "-option-" + item.Text + "'" +
+                    (item.Selected ? " selected='selected'" : "") +
+                    ">" +
+                    item.Text +
+                    "</option>"
+                );
             }
 
             dropdown.InnerHtml = options.ToString();


### PR DESCRIPTION
Bugfix, where the edit form now honours the API-provided selected value for the IEBT field "accommodation changes" (only field for which this helper method is called).

Also tidies the generated HTML, to include relevant spaces between attribute IDs/values.

#204172