### PR TITLE
Test Locators on establishment details page

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Details.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Details.cshtml
@@ -101,7 +101,7 @@
             <span id="establishment-name">@(Model.Establishment.Name.Clean() ?? "(name not recorded)")</span>
         </h1>
 
-        <p class="urn establishment-fine-detail"><abbr id="urn-value" title="Unique Reference Number">URN</abbr>: @Model.Establishment.Urn</p>
+        <p class="urn establishment-fine-detail"><abbr id="urn-label" title="Unique Reference Number">URN</abbr>: <span id="urn-value"> @Model.Establishment.Urn </span></p>
         <p id="establishment-type" class="establishment-type establishment-fine-detail">@Model.TypeName</p>
         <p id="establishment-data-download" class="establishment-data-download">
             @Html.RouteLink("Download establishment data", "EstabDataDownload", new
@@ -117,7 +117,7 @@
         @if (Model.LegalParentGroup != null)
         {
             <div>
-                <p class="establishment-fine-detail">@Model.GetGroupFieldLabel(Model.LegalParentGroup): @Html.RouteLink(Model.LegalParentGroupRouteDto.Label, Model.LegalParentGroupRouteDto.RouteName, Model.LegalParentGroupRouteDto.RouteValues, HtmlHelper.AnonymousObjectToHtmlAttributes(new { @class = "govuk-breadcrumbs__link" }))</p>
+                <p class="establishment-fine-detail">@Model.GetGroupFieldLabel(Model.LegalParentGroup): @Html.RouteLink(Model.LegalParentGroupRouteDto.Label, Model.LegalParentGroupRouteDto.RouteName, Model.LegalParentGroupRouteDto.RouteValues, HtmlHelper.AnonymousObjectToHtmlAttributes(new { @class = "govuk-breadcrumbs__link", id = "parent-group-link" }))</p>
             </div>
         }
 


### PR DESCRIPTION
Added in a couple of locators on the URN number at the top of the page and a locator for the establishment parent group link.