### PR TITLE
Do not clear gov role on error

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/GovernorController.cs
@@ -76,7 +76,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
          Route(ESTAB_EDIT_GOVERNANCE, Name = "EstabEditGovernance"),
          HttpGet, EdubaseAuthorize]
         public async Task<ActionResult> Edit(int? groupUId, int? establishmentUrn, int? removalGid,
-            int? duplicateGovernorId, bool roleAlreadyExists = false)
+            int? duplicateGovernorId, bool roleAlreadyExists = false, eLookupGovernorRole? selectedRole = null)
         {
             Guard.IsTrue(groupUId.HasValue || establishmentUrn.HasValue,
                 () => new InvalidParameterException(
@@ -118,6 +118,9 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                     viewModel.GovernorShared = true;
                 }
             }
+
+            // Set the selected selectedRole (used to pre-fill the drop-down where there is an error)
+            ViewData.Add("SelectedGovernorRole", selectedRole);
 
             if (duplicateGovernorId.HasValue)
             {
@@ -244,7 +247,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 if (!await RoleAllowed(role.Value, groupUId, establishmentUrn, User))
                 {
                     return RedirectToRoute(establishmentUrn.HasValue ? "EstabEditGovernance" : "GroupEditGovernance",
-                        new { establishmentUrn, groupUId, roleAlreadyExists = true });
+                        new { establishmentUrn, groupUId, roleAlreadyExists = true, selectedRole = role });
                 }
 
                 if (establishmentUrn.HasValue && EnumSets.eSharedGovernorRoles.Contains(role.Value))

--- a/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
@@ -89,6 +89,16 @@
                                         selectListItem.Text = factoryName;
                                     }
 
+                                    // If we have been bounced back to this form (e.g., due to an error), pre-select whichever role the user previously attempted to submit.
+                                    // Came up in the context of "The role already contains an appointee" error, where the first item would be pre-selected and would be
+                                    // misleading to the user (as it would look like the first entry already has an appointee, rather than whatever the user submitted).
+                                    // See also WCAG 2.2 requirements to not clear any form fields when validating users' input.
+                                    // https://design-system.service.gov.uk/patterns/validation/#wcag-edit-to-correct-errors
+                                    if(ViewData.ContainsKey("SelectedRole") && ViewData["SelectedRole"] == x)
+                                    {
+                                        selectListItem.Selected = true;
+                                    }
+
                                     return selectListItem;
                                 });
                         }


### PR DESCRIPTION
Where we deny the user creating a new governance role record because a person in that role already exists (e.g., chair of trustees, accounting officer, and the new governance professional roles), the drop-down box currently defaults to whichever entry is top of the list.

During governance professional testing, it is felt this is misleading as it initially looks like whatever value is first in the list already has an appointee.

Additionally, WCAG 2.2 requires form fields to not be cleared when validating user input.
https://design-system.service.gov.uk/patterns/validation/#wcag-edit-to-correct-errors

![image](https://github.com/DFE-Digital/get-information-about-schools/assets/96429508/d1213832-7ca3-4f1d-81fb-a2ad27b32b63)


For this reason, this PR has a basic implementation which causes the drop-down to pre-select whichever role the user submitted.