### PR TITLE
Bg/212981 Remove previously allowed condition from PairwiseGovernanceProfessionalRolesAllowedCombinations

### DIFF
--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -579,10 +579,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                     new object[] {eLookupGovernorRole.Group_SharedGovernanceProfessional, eLookupGovernorRole.GovernanceProfessionalToAMat},
                     new object[] {eLookupGovernorRole.GovernanceProfessionalToAMat, eLookupGovernorRole.Group_SharedGovernanceProfessional},
 
-                    // - #198772 / #197361 : Establishment within a SAT can have "one-each" of "Governance professional to an individual academy or free school" and "Governance professional for single-academy trust (SAT)"
-                    new object[] {eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, eLookupGovernorRole.GovernanceProfessionalToASat},
-                    new object[] {eLookupGovernorRole.GovernanceProfessionalToASat, eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool},
-
                     // - #198239: System should allow adding a Governance professional to a federation if a record for Governance professional to a local authority maintained is already recorded.
                     new object[] {eLookupGovernorRole.GovernanceProfessionalToAFederation, eLookupGovernorRole.GovernanceProfessionalToALocalAuthorityMaintainedSchool},
                     new object[] {eLookupGovernorRole.GovernanceProfessionalToALocalAuthorityMaintainedSchool, eLookupGovernorRole.GovernanceProfessionalToAFederation},


### PR DESCRIPTION
Remove previously allowed condition from PairwiseGovernanceProfessionalRolesAllowedCombinations - This will allow the condition to be tested in the: Gov_AddEditOrReplace_RoleSpecified_GovernanceProfessional_RoleAlreadyExists_DisallowedThereforeReject test method.

There are 2 combinations in an ignore list (in the GovernorControllerTests) - currently the test passes, as these combinations are not being tested (ignored)
However...these shouldn't be in the ignore list.

When they are taken out, and the test properly checks them, they pass successfully - ticket just to move into current place.