### PR TITLE
Update visual display of the logs/caches links on the tools page - only if a backoffice user.

### DIFF
--- a/Web/Edubase.Web.UI/Controllers/ToolsController.cs
+++ b/Web/Edubase.Web.UI/Controllers/ToolsController.cs
@@ -90,7 +90,9 @@ namespace Edubase.Web.UI.Controllers
                 UserCanBulkAssociateEstabs2Groups = User.InRole(AuthorizedRoles.CanBulkAssociateEstabs2Groups),
                 UserCanDownloadMATClosureReport = User.InRole(AuthorizedRoles.CanManageAcademyTrusts),
                 UserCanManageNotifications = User.InRole(AuthorizedRoles.IsAdmin),
-                UserCanManageNews = User.InRole(AuthorizedRoles.IsAdmin)
+                UserCanManageNews = User.InRole(AuthorizedRoles.IsAdmin),
+                UserCanViewLogs = User.InRole(AuthorizedRoles.IsAdmin),
+                UserCanResetCaches = User.InRole(AuthorizedRoles.IsAdmin),
             };
 
             return View(viewModel);

--- a/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
+++ b/Web/Edubase.Web.UI/Models/ToolsViewModel.cs
@@ -33,6 +33,8 @@ namespace Edubase.Web.UI.Models
         public bool UserCanDownloadMATClosureReport { get; internal set; }
         public bool UserCanManageNotifications { get; internal set; }
         public bool UserCanManageNews { get; internal set; }
+        public bool UserCanViewLogs { get; internal set; }
+        public bool UserCanResetCaches { get; internal set; }
 
         public List<LinkAction> GetCreateActions(HtmlHelper htmlHelper)
         {
@@ -275,19 +277,25 @@ namespace Edubase.Web.UI.Models
 
         public List<LinkAction> GetSupportActions(HtmlHelper htmlHelper)
         {
-            var retVal = new List<LinkAction>
+            var retVal = new List<LinkAction>();
+
+            if (UserCanViewLogs)
             {
-                new LinkAction
+                retVal.Add(new LinkAction
                 {
                     Link = htmlHelper.ActionLink("View logs", "ViewLogs", "Admin"),
                     Description = "View logs, including those linked to a user-facing error code."
-                },
-                new LinkAction
+                });
+            }
+
+            if (UserCanResetCaches)
+            {
+                retVal.Add(new LinkAction
                 {
                     Link = htmlHelper.ActionLink("Clear cache", "ClearCache", "Admin"),
                     Description = "Clear the Redis cache and C# memory cache."
-                }
-            };
+                });
+            }
 
             return retVal;
         }


### PR DESCRIPTION
Update visual display of the logs/caches links on the tools page - only if a backoffice user.

Note this is just visual display of the link - accessing the pages is already denied/prevented.

#208253