### PR TITLE
215376  governor search timeout

### DIFF
--- a/Web/Edubase.Services.Texuna/Governors/GovernorsReadApiService.cs
+++ b/Web/Edubase.Services.Texuna/Governors/GovernorsReadApiService.cs
@@ -14,11 +14,13 @@ namespace Edubase.Services.Texuna.Governors
     public class GovernorsReadApiService : IGovernorsReadService
     {
         private readonly HttpClientWrapper _httpClient;
+        private readonly HttpClientWrapper _governorSearchHttpClient;
         private readonly IEstablishmentReadService _establishmentReadService;
 
-        public GovernorsReadApiService(HttpClientWrapper httpClient, IEstablishmentReadService establishmentReadService)
+        public GovernorsReadApiService(HttpClientWrapper httpClient, HttpClientWrapper governorSearchHttpClient, IEstablishmentReadService establishmentReadService)
         {
             _httpClient = httpClient;
+            _governorSearchHttpClient = governorSearchHttpClient;
             _establishmentReadService = establishmentReadService;
         }
 
@@ -30,18 +32,18 @@ namespace Edubase.Services.Texuna.Governors
             var retVal = (await _httpClient.GetAsync<GovernorModel>($"governor/{gid}", principal)).GetResponse();
             return retVal;
         }
-        
+
         public async Task<GovernorsDetailsDto> GetGovernorListAsync(int? urn = default(int?), int? groupUId = default(int?), IPrincipal principal = null)
         {
             var retVal = (await _httpClient.GetAsync<GovernorsDetailsTexunaDto>($"governors?{(groupUId.HasValue ? "uid" : "urn")}={(urn.HasValue ? urn : groupUId)}", principal)).GetResponse();
             return retVal;
         }
 
-        public async Task<GovernorPermissions> GetGovernorPermissions(int? urn = default(int?), int? groupUId = default(int?), IPrincipal principal = null) 
+        public async Task<GovernorPermissions> GetGovernorPermissions(int? urn = default(int?), int? groupUId = default(int?), IPrincipal principal = null)
             => (await _httpClient.GetAsync<GovernorPermissions>($"governors/permissions?{(groupUId.HasValue ? "uid" : "urn")}={(urn.HasValue ? urn : groupUId)}", principal)).GetResponse();
 
-        public async Task<ApiPagedResult<SearchGovernorModel>> SearchAsync(GovernorSearchPayload payload, IPrincipal principal) 
-            => (await _httpClient.PostAsync<ApiPagedResult<SearchGovernorModel>>("governor/search", payload, principal)).GetResponse();
+        public async Task<ApiPagedResult<SearchGovernorModel>> SearchAsync(GovernorSearchPayload payload, IPrincipal principal)
+            => (await _governorSearchHttpClient.PostAsync<ApiPagedResult<SearchGovernorModel>>("governor/search", payload, principal)).GetResponse();
 
         public async Task<IEnumerable<GovernorModel>> GetSharedGovernorsAsync(int establishmentUrn, IPrincipal principal)
         {

--- a/Web/Edubase.Web.UI/App_Start/IocConfig.cs
+++ b/Web/Edubase.Web.UI/App_Start/IocConfig.cs
@@ -357,22 +357,6 @@ namespace Edubase.Web.UI
             return client;
         }
 
-        private static HttpClient CreatOSPlacesClient()
-        {
-            if (!int.TryParse(ConfigurationManager.AppSettings["OSPlacesApiServices_Timeout"], out var timeoutsettings))
-            {
-                timeoutsettings = 10;
-            }
-
-            var client = new HttpClient
-            {
-                BaseAddress = new Uri(ConfigurationManager.AppSettings["OSPlacesUrl"]),
-                Timeout = TimeSpan.FromSeconds(timeoutsettings)
-            };
-
-            return client;
-        }
-
         public static HttpClient CreateGovernorSearchClient(string governorSearchApiAddress, string governorSearchApiUsername, string governorSearchApiPassword)
         {
             // If the given values are empty, default to using the generic/standard API address and credentials
@@ -407,6 +391,22 @@ namespace Edubase.Web.UI
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(Basic,
                     new BasicAuthCredentials(governorSearchApiUsername, governorSearchApiPassword).ToString());
             }
+
+            return client;
+        }
+
+        private static HttpClient CreatOSPlacesClient()
+        {
+            if (!int.TryParse(ConfigurationManager.AppSettings["OSPlacesApiServices_Timeout"], out var timeoutsettings))
+            {
+                timeoutsettings = 10;
+            }
+
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri(ConfigurationManager.AppSettings["OSPlacesUrl"]),
+                Timeout = TimeSpan.FromSeconds(timeoutsettings)
+            };
 
             return client;
         }

--- a/Web/Edubase.Web.UI/App_Start/IocConfig.cs
+++ b/Web/Edubase.Web.UI/App_Start/IocConfig.cs
@@ -321,6 +321,20 @@ namespace Edubase.Web.UI
 
         public static HttpClient CreateLookupClient(string lookupApiAddress, string lookupApiUsername, string lookupApiPassword)
         {
+            // If the given values are empty, default to using the generic/standard API address and credentials
+            if (string.IsNullOrEmpty(lookupApiAddress))
+            {
+                lookupApiAddress = ConfigurationManager.AppSettings["TexunaApiBaseAddress"];
+            }
+            if (string.IsNullOrEmpty(lookupApiUsername))
+            {
+                lookupApiUsername = ConfigurationManager.AppSettings["api:Username"];
+            }
+            if (string.IsNullOrEmpty(lookupApiPassword))
+            {
+                lookupApiPassword = ConfigurationManager.AppSettings["api:Password"];
+            }
+
             var lookupUri = new Uri(lookupApiAddress);
 
             if (!int.TryParse(ConfigurationManager.AppSettings["LookupClient_Timeout"], out var timeoutsettings))
@@ -361,6 +375,20 @@ namespace Edubase.Web.UI
 
         public static HttpClient CreateGovernorSearchClient(string governorSearchApiAddress, string governorSearchApiUsername, string governorSearchApiPassword)
         {
+            // If the given values are empty, default to using the generic/standard API address and credentials
+            if (string.IsNullOrEmpty(governorSearchApiAddress))
+            {
+                governorSearchApiAddress = ConfigurationManager.AppSettings["TexunaApiBaseAddress"];
+            }
+            if (string.IsNullOrEmpty(governorSearchApiUsername))
+            {
+                governorSearchApiUsername = ConfigurationManager.AppSettings["api:Username"];
+            }
+            if (string.IsNullOrEmpty(governorSearchApiPassword))
+            {
+                governorSearchApiPassword = ConfigurationManager.AppSettings["api:Password"];
+            }
+
             var governorSearchUri = new Uri(governorSearchApiAddress);
 
             if (!int.TryParse(ConfigurationManager.AppSettings["GovernorSearchClient_Timeout"], out var timeoutsettings))

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -235,6 +235,10 @@
     <add key="LookupApiUsername" value="rest-api-user"/>
     <add key="LookupApiPassword" value=""/>
 
+    <add key="GovernorSearchApiBaseAddress" value=""/>
+    <add key="GovernorSearchApiUsername" value="rest-api-user"/>
+    <add key="GovernorSearchApiPassword" value=""/>
+
 
     <!-- ==== 3RD PARTY API DEPENDENCIES ==== -->
     <!--
@@ -297,7 +301,7 @@
     <add key="FscpdPassword" value=""/>
 
     <add key="OSPlacesUrl" value="https://api.os.uk/" />
-    
+
     <add key="AzureMapsUrl" value="https://atlas.microsoft.com" />
 
     <!-- ==== WEBSITE AUTHENTICATION / AUTHORISATION ==== -->
@@ -316,7 +320,7 @@
     <!-- <add key="HttpAuthModule.Credentials" value="" /> -->
     <add key="HttpAuthModule.IgnoreIPAddresses" value="127.0.0.1;::1"/>
 
-    
+
     <!-- TIMEOUT SETTINGS -->
     <add key="FBService_Timeout" value="2" />
     <add key="FBService_RetryIntervals" value="1" />
@@ -324,6 +328,9 @@
     <add key="HttpClient_Timeout" value="30" />
 
     <add key="LookupClient_Timeout" value="10" />
+
+    <!-- Governor search currently performs extremely poorly, therefore increase timeout specifically for this to accommodate -->
+    <add key="GovernorSearchClient_Timeout" value="45" />
 
     <add key="FscpdClient_Timeout" value="2" />
     <add key="FscpdClient_RetryIntervals" value="1" />


### PR DESCRIPTION
Governor search is extremely poorly performing currently, and a quick-win broad increase to the general HTTP client timeout previously allowed the site to continue functioning. Future work may improve the performance of this API but in the meanwhile we feel it would be helpful to have a more targeted increase to the timeout.


This PR introduces a new HTTP client specifically for the governor search API query, to allow for a narrowly-defined increased timeout specifically for this only.

(currently the increased timeout workaround applies generically to all the default HttpClient requests)

Note that this change is backwards compatible, by defaulting back to the generic Texuna Java API connection details/credentials if the more-specific (governor-search) details/credentials are not provided via configuration. 

(allows overriding if desired, but does not force it)

#215376