### PR TITLE
Trivial fix, for display of original signatory member/chair of trustees

### DIFF
--- a/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/GovernorViewModel.cshtml
@@ -147,7 +147,7 @@ else
         <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.IsOriginalSignatoryMember)">
             @Html.LabelFor(x => x.IsOriginalSignatoryMember, "Original signatory member", new { @class = "govuk-label" })
             @Html.ValidationMessageFor(x => x.IsOriginalSignatoryMember, null, new { @class = "govuk-error-message" })
-            @Html.DropDownListFor(x => x.IsOriginalSignatoryMember, Model.YesNoSelect, new { @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.IsOriginalSignatoryMember)) })
+            @Html.DropDownListFor(x => x.IsOriginalSignatoryMember, Model.YesNoSelect, new { @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.IsOriginalSignatoryMember)) })
         </div>
     }
 }
@@ -159,7 +159,7 @@ else
         <div class="govuk-form-group @Html.ValidationCssClassFor(x => x.IsOriginalChairOfTrustees)">
             @Html.LabelFor(x => x.IsOriginalChairOfTrustees, "Original chair of trustees", new { @class = "govuk-label" })
             @Html.ValidationMessageFor(x => x.IsOriginalChairOfTrustees, null, new { @class = "govuk-error-message" })
-            @Html.DropDownListFor(x => x.IsOriginalChairOfTrustees, Model.YesNoSelect, new { @class = string.Concat("govuk-input ", Html.TextBoxValidationClass(x => x.IsOriginalChairOfTrustees))})
+            @Html.DropDownListFor(x => x.IsOriginalChairOfTrustees, Model.YesNoSelect, new { @class = string.Concat("govuk-select ", Html.TextBoxValidationClass(x => x.IsOriginalChairOfTrustees))})
         </div>
     }
 }


### PR DESCRIPTION
Currently these fields are styled as a `govuk-input` (while behaving as a select/drop-down).

This PR fixes the the `govuk` class to correctly style these fields as a select/dropdown, by using `govuk-select` instead of `govuk-input`.

- **BEFORE**: 
  - ![image](https://github.com/user-attachments/assets/50fb4118-05e5-41b8-adeb-8d4e63289fb6)
  - ![image](https://github.com/user-attachments/assets/b2c409dd-3725-4e6f-b8f9-e9aea3d53457)
- **AFTER**: 
  - ![image](https://github.com/user-attachments/assets/1af27238-2e97-41de-8dd5-ad52bca71f4a)
  - ![image](https://github.com/user-attachments/assets/7c1e01b5-f30b-4c0f-889c-4abfeda10469)

