### PR TITLE
AZTLogger

### DIFF
--- a/Web/Edubase.Web.UI/Filters/ExceptionFilter.cs
+++ b/Web/Edubase.Web.UI/Filters/ExceptionFilter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Configuration;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 using Microsoft.AspNet.Identity;
@@ -28,6 +29,15 @@ namespace Edubase.Web.UI.Filters
                 throw new ArgumentNullException(nameof(filterContext));
             }
 
+            var ctx = filterContext.HttpContext;
+            var exception = filterContext.Exception;
+
+            if (!ShouldLogException(exception, ctx))
+            {
+                filterContext.ExceptionHandled = true;
+                return;
+            }
+
             if (filterContext.Exception is EdubaseException) // domain / purposeful exception - not logged
             {
                 var domainException = filterContext.Exception as EdubaseException;
@@ -46,8 +56,7 @@ namespace Edubase.Web.UI.Filters
             }
             else // unhandled/unexpected exception; log it and tell the user.
             {
-                var ctx = filterContext.HttpContext;
-                var msg = Log(ctx, filterContext.Exception);
+                var msg = Log(ctx, exception);
 
                 // Making this "forwarded-header-aware" is not strictly required,
                 // but it's easier and safer to be consistent and just do it everywhere.
@@ -99,12 +108,14 @@ namespace Edubase.Web.UI.Filters
                 // ignored
             }
 
-            WebLogMessage msg = new WebLogMessage {
+            var logLevel = GetLogLevel(exception);
+
+            var msg = new WebLogMessage {
                 ClientIpAddress = ctx?.Request?.UserHostAddress,
                 Environment = ConfigurationManager.AppSettings["Environment"],
                 Exception = exception?.ToString(),
                 HttpMethod = httpMethod,
-                Level = LogMessage.LogLevel.ERROR,
+                Level = logLevel,
                 ReferrerUrl = ctx?.Request.UrlReferrer?.ToString(),
                 Message = exception?.GetBaseException().Message,
                 Url = ctx?.Request.Url?.ToString(),
@@ -121,6 +132,48 @@ namespace Edubase.Web.UI.Filters
             }
 
             return msg;
+        }
+
+        private LogMessage.LogLevel GetLogLevel(Exception exception)
+        {
+            LogMessage.LogLevel loglevel;
+
+            switch (exception)
+            {
+                case TaskCanceledException _:
+                    loglevel = LogMessage.LogLevel.INFORMATION;
+                    break;
+                case ArgumentException _:
+                    loglevel = LogMessage.LogLevel.WARNING;
+                    break;
+                case InvalidOperationException _:
+                    loglevel = LogMessage.LogLevel.WARNING;
+                    break;
+                case HttpAntiForgeryException _:
+                    loglevel = LogMessage.LogLevel.ERROR;
+                    break;
+                default:
+                    loglevel = LogMessage.LogLevel.ERROR;
+                    break;
+            }
+
+            return loglevel;
+        }
+
+        private bool ShouldLogException(Exception ex, HttpContextBase context)
+        {
+            if (ex is HttpAntiForgeryException)
+            {
+                // dont log HttpAntiForgeryException if a session timeout
+                return context?.Session != null && context.Session.IsNewSession;
+            }
+
+            if (ex is TaskCanceledException)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
LogLevel shows the severity levels. ShouldLogException is used to determine if we need to log the errors at all.