### PR TITLE
End date for 'shared governance professional - establishment' is now optional, per UAT

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Controllers/SharedGovernorController.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Controllers/SharedGovernorController.cs
@@ -89,6 +89,12 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers
                 {
                     newGovernor.Selected = previousGovernor.Selected;
                 }
+
+                // Retain the user-submitted selection (even if it is invalid):
+                if(newGovernor.Id.ToString() == model.SelectedGovernorId)
+                {
+                    newGovernor.Selected = true;
+                }
             }
 
             model.Governors = governors;

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
@@ -9,6 +9,9 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
     {
         public SelectSharedGovernorViewModelValidator()
         {
+            // This section for "singular" governor roles (i.e., roles that can only have one appointee)
+            // On the web UI, these are displayed as radio buttons and the `Selected` value is ignored.
+            // Instead, the property `SelectedGovernorId` is used to track which governor is selected.
             When(x => EnumSets.eSingularGovernorRoles.Contains(x.Role), () =>
             {
                 // Ensure the governor ID is selected and valid
@@ -17,44 +20,42 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
                     .WithMessage("Required")
                     .WithSummaryMessage("Select a governor");
 
-                // Validate appointment start date
+                // Validate appointment start date (only if/where the governor is selected)
                 RuleFor(x => x.SelectedGovernorId)
                     .Must(IsAppointmentStartDateValid)
                     .When(x => x.SelectedGovernorId != null)
                     .WithMessage("Required")
                     .WithMessage(y =>
                     {
-
-                        int.TryParse(y.SelectedGovernorId, out int governorId);
-
+                        int.TryParse(y.SelectedGovernorId, out var governorId);
                         var selectedGovernorRecord = y
                             .Governors
                             .SingleOrDefault(g => g.Id == governorId);
 
-                        return "Enter a valid appointment end date for " + (selectedGovernorRecord?.FullName ?? "unknown governor") + " (" + y.SelectedGovernorId + ")";
+                        return $"Enter a valid appointment end date for {selectedGovernorRecord?.FullName ?? "unknown governor"} ({y.SelectedGovernorId})";
                     });
 
-                // Validate appointment end date
+                // Validate appointment end date (only if/where the governor is selected, and the role is not a `Shared Governance Professional - Establishment`)
                 RuleFor(x => x.SelectedGovernorId)
                     .Must(IsAppointmentEndDateValid)
                     .When(x => x.SelectedGovernorId != null && x.Role != eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
                     .WithMessage("Required")
                     .WithMessage(y =>
                     {
-
-                        int.TryParse(y.SelectedGovernorId, out int governorId);
-
+                        int.TryParse(y.SelectedGovernorId, out var governorId);
                         var selectedGovernorRecord = y
                             .Governors
                             .SingleOrDefault(g => g.Id == governorId);
 
-                        return "Enter a valid appointment end date for " + (selectedGovernorRecord?.FullName ?? "unknown governor") + " (" + y.SelectedGovernorId + ")";
+                        return $"Enter a valid appointment end date for {(selectedGovernorRecord?.FullName ?? "unknown governor")} ({y.SelectedGovernorId})";
                     });
             });
 
 
-            // When the role may have multiple appointees (i.e., is not "singular"),
-            // validations need to be performed on the list of governors
+            // This section for roles that can have multiple appointees.
+            // On the web UI, these are displayed as checkboxes and the `Selected` value for each governor
+            // is used to track which governors are selected (the `SelectedGovernorId` is ignored).
+            // In this case, validations need to be applied to all selected governors (not just a single "selected" governor).
             When(x => !EnumSets.eSingularGovernorRoles.Contains(x.Role), () =>
             {
                 // Ensure at least one governor is selected (can be multiple, and at least one needs to be selected)
@@ -63,21 +64,21 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
                     .WithMessage("Required")
                     .WithSummaryMessage("Select at least one governor");
 
+                // Validate appointment start date and end date for each selected governor (only if/where the governor is marked as selected)
                 RuleForEach(z => z.Governors)
                     .ChildRules(x => x
                         .RuleFor(y => y.AppointmentStartDate)
                         .Must(y => y.IsValid())
                         .When(y => y.Selected)
                         .WithMessage("Required")
-                        .WithSummaryMessage(y => "Enter a valid appointment start date for " + y.FullName + " (" + y.Id + ")")
-
+                        .WithSummaryMessage(y => $"Enter a valid appointment start date for {y.FullName} ({y.Id})")
                     )
                     .ChildRules(x => x
                         .RuleFor(y => y.AppointmentEndDate)
                         .Must(y => y.IsValid())
                         .When(y => y.Selected)
                         .WithMessage("Required")
-                        .WithSummaryMessage(y => "Enter a valid appointment end date for " + y.FullName + " (" + y.Id + ")")
+                        .WithSummaryMessage(y => $"Enter a valid appointment end date for {y.FullName} ({y.Id})")
                     );
             });
         }
@@ -108,7 +109,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
                 .SingleOrDefault(g => g.Id == governorId);
 
             return selectedGovernorRecord?.AppointmentStartDate.IsValid() ?? false;
-
         }
 
         private static bool IsAppointmentEndDateValid(SelectSharedGovernorViewModel model, string selectedId)

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Edubase.Services.Enums;
 using Edubase.Web.UI.Validation;
 using FluentValidation;
@@ -23,7 +22,18 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
                     .WithSummaryMessage("An appointment start date is required");
 
                 RuleFor(x => x)
-                    .Must(x => x.SelectedGovernorId != null && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentEndDate.IsValid())
+                    .Must(x =>
+                    {
+                        if(x.Role == eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
+                        {
+                            // End date is mandatory for shared governors at the establishment level,
+                            // But is optional for shared governance professional - establishment (per #230911).
+                            return true;
+                        }
+
+                        return x.SelectedGovernorId != null
+                               && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentEndDate.IsValid();
+                    })
                     .WithMessage("Required")
                     .WithSummaryMessage("An appointment end date is required");
             });
@@ -41,7 +51,18 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
                     .WithSummaryMessage("An appointment start date is required");
 
                 RuleFor(x => x)
-                    .Must(x => x.Governors.Where(g => g.Selected).All(g => g.AppointmentEndDate.IsValid()))
+                    .Must(x =>
+                    {
+                        if(x.Role == eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
+                        {
+                            // End date is mandatory for shared governors at the establishment level,
+                            // But is optional for shared governance professional - establishment (per #230911).
+                            return true;
+                        }
+
+                        return x.SelectedGovernorId != null
+                               && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentEndDate.IsValid();
+                    })
                     .WithMessage("Required")
                     .WithSummaryMessage("An appointment end date is required");
             });

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/Validators/SelectSharedGovernorViewModelValidator.cs
@@ -11,61 +11,97 @@ namespace Edubase.Web.UI.Areas.Governors.Models.Validators
         {
             When(x => EnumSets.eSingularGovernorRoles.Contains(x.Role), () =>
             {
-                RuleFor(x => x)
-                    .Must(x => x.SelectedGovernorId != null && x.Governors.Count(g => g.Id == int.Parse(x.SelectedGovernorId)) == 1)
+                // Ensure the governor ID is selected and valid
+                RuleFor(x => x.SelectedGovernorId)
+                    .NotNull()
+                    .WithMessage("Required")
+                    .WithSummaryMessage("You must select a governor")
+                    .Must(IsValidGovernorSelected)
                     .WithMessage("Required")
                     .WithSummaryMessage("You must select a governor");
 
-                RuleFor(x => x)
-                    .Must(x => x.SelectedGovernorId != null && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentStartDate.IsValid())
+                // Validate appointment start date
+                RuleFor(x => x.SelectedGovernorId)
+                    .Must(IsAppointmentStartDateValid)
+                    .When(x => x.SelectedGovernorId != null)
                     .WithMessage("Required")
                     .WithSummaryMessage("An appointment start date is required");
 
-                RuleFor(x => x)
-                    .Must(x =>
-                    {
-                        if(x.Role == eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
-                        {
-                            // End date is mandatory for shared governors at the establishment level,
-                            // But is optional for shared governance professional - establishment (per #230911).
-                            return true;
-                        }
-
-                        return x.SelectedGovernorId != null
-                               && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentEndDate.IsValid();
-                    })
-                    .WithMessage("Required")
-                    .WithSummaryMessage("An appointment end date is required");
+                // Validate appointment end date
+                RuleFor(x => x.SelectedGovernorId)
+                    .Must(IsAppointmentEndDateValid)
+                    .When(x => x.SelectedGovernorId != null &&
+                               x.Role != eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
+                    .WithMessage("An appointment end date is required");
             });
 
+
+            // When the role may have multiple appointees (i.e., is not "singular"),
+            // validations need to be performed on the list of governors
             When(x => !EnumSets.eSingularGovernorRoles.Contains(x.Role), () =>
             {
-                RuleFor(x => x)
-                    .Must(x => x.Governors.Any(g => g.Selected))
+                // Ensure at least one governor is selected (can be multiple, and at least one needs to be selected)
+                RuleFor(x => x.Governors)
+                    .Must(x => x.Any(g => g.Selected))
                     .WithMessage("Required")
-                    .WithSummaryMessage("You must select a governor");
+                    .WithSummaryMessage("At least one governor must be selected");
 
-                RuleFor(x => x)
-                    .Must(x => x.Governors.Where(g => g.Selected).All(g => g.AppointmentStartDate.IsValid()))
-                    .WithMessage("Required")
-                    .WithSummaryMessage("An appointment start date is required");
-
-                RuleFor(x => x)
-                    .Must(x =>
-                    {
-                        if(x.Role == eLookupGovernorRole.Establishment_SharedGovernanceProfessional)
-                        {
-                            // End date is mandatory for shared governors at the establishment level,
-                            // But is optional for shared governance professional - establishment (per #230911).
-                            return true;
-                        }
-
-                        return x.SelectedGovernorId != null
-                               && x.Governors.Single(g => g.Id == int.Parse(x.SelectedGovernorId)).AppointmentEndDate.IsValid();
-                    })
-                    .WithMessage("Required")
-                    .WithSummaryMessage("An appointment end date is required");
+                RuleForEach(z => z.Governors)
+                    .ChildRules(x => x
+                        .RuleFor(y => y.AppointmentStartDate)
+                        .Must(y => y.IsValid())
+                        .When(y => y.Selected)
+                        .WithMessage("Required")
+                        .WithSummaryMessage("An appointment start date is required")
+                    )
+                    // TODO: This rule is not required for the Establishment_SharedGovernanceProfessional role
+                    .ChildRules(x => x
+                        .RuleFor(y => y.AppointmentEndDate)
+                        .Must(y => y.IsValid())
+                        .When(y => y.Selected)
+                        .WithMessage("Required")
+                        .WithSummaryMessage("An appointment end date is required")
+                    );
             });
+        }
+
+        private static bool IsValidGovernorSelected(SelectSharedGovernorViewModel model, string selectedId)
+        {
+            if (!int.TryParse(selectedId, out int governorId))
+            {
+                return false;
+            }
+
+            var selectedGovernorRecord = model
+                .Governors
+                .SingleOrDefault(g => g.Id == governorId);
+
+            return selectedGovernorRecord != null;
+        }
+
+        private static bool IsAppointmentStartDateValid(SelectSharedGovernorViewModel model, string selectedId)
+        {
+            if (!int.TryParse(selectedId, out int governorId))
+            {
+                return false;
+            }
+
+            var selectedGovernorRecord = model
+                .Governors
+                .SingleOrDefault(g => g.Id == governorId);
+
+            return selectedGovernorRecord?.AppointmentStartDate.IsValid() ?? false;
+
+        }
+
+        private static bool IsAppointmentEndDateValid(SelectSharedGovernorViewModel model, string selectedId)
+        {
+            if (int.TryParse(selectedId, out int governorId))
+            {
+                return model.Governors.SingleOrDefault(g => g.Id == governorId)?.AppointmentEndDate.IsValid() ?? false;
+            }
+
+            return false;
         }
     }
 }

--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/GiasReOrderValidationSummary.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/GiasReOrderValidationSummary.js
@@ -4,7 +4,7 @@ const GiasReOrderValidationSummary = function () {
   const errorSummaryList = $errorSummary.find('ul');
   const summaryMessageItems = $errorSummary.find('li');
   const inPageErrorFields = $('#main-content').find('.govuk-form-group--error');
-  
+
   if (inPageErrorFields.length < 2 || window.blockReOrder) {
     return;
   }

--- a/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/DateTimeViewModel.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/EditorTemplates/DateTimeViewModel.cshtml
@@ -15,6 +15,16 @@
     string tooltipUnderscoredTitle = null;
     var describedByIds = "";
 
+    // Full field ID is required where there are multiple date fields on the same page.
+    // Previously, variations of `@legendPrefix + @ViewData.ModelMetadata.PropertyName`
+    // were used, but if there are multiple `StartDate` properties on the page then the
+    // IDs would clash. This is a more robust solution.
+    var fullFieldId = ViewData.TemplateInfo.GetFullHtmlFieldName(Model?.Label)
+        .Replace(".", "_")
+        .Replace("[", "_")
+        .Replace("]", "_");
+
+
     if (ViewData["dateHint"] != null)
     {
         dateHint = ViewData["dateHint"].ToString();
@@ -48,7 +58,8 @@
     else
     {
         classBinding = "class=\"govuk-form-group create-edit-form-group date-group "
-                       + Html.ValidationGroupCssClass(ViewData.ModelMetadata.PropertyName) + " "
+                       // + Html.ValidationGroupCssClass(ViewData.ModelMetadata.PropertyName) + " "
+                       + Html.ValidationGroupCssClass(fullFieldId) + " "
                        + Html.ValidationCssClassFor(x => x) + " "
                        + Html.ValidationCssClassFor(x => x.Day) + " "
                        + Html.ValidationCssClassFor(x => x.Month) + " "
@@ -72,19 +83,21 @@
     tooltipText = ViewData["tooltipText"]?.ToString();
     //}
 
+    var legendId = string.Concat(legendPrefix, fullFieldId);
+
 }
 <div @Html.Raw(classBinding)>
 
     @{
-        describedByIds = describedByIds + " " + @legendPrefix + @ViewData.ModelMetadata.PropertyName + "-hint";
+        describedByIds = describedByIds + " " + legendId + "-hint";
     }
     @{
         if (!disableHint)
         {
-            describedByIds = describedByIds + " " + @ViewData.ModelMetadata.PropertyName + "-errors";
+            describedByIds = describedByIds + " " + @fullFieldId + "-errors";
         }
     }
-    <fieldset id="date-error" class="govuk-fieldset range-group @fieldsetClassName">
+    <fieldset id="@fullFieldId-date-error" class="govuk-fieldset range-group @fieldsetClassName">
         @if (ViewData["inFilters"] != null)
         {
             <span class="govuk-error-message hidden">Please check the date(s) you have entered</span>
@@ -101,7 +114,7 @@
             </div>
         }
 
-        <legend class="govuk-fieldset__legend @Html.Conditional(hideLegend, "hidden")" id="@legendPrefix@ViewData.ModelMetadata.PropertyName">
+        <legend class="govuk-fieldset__legend @Html.Conditional(hideLegend, "hidden")" id="@fullFieldId">
             @(string.IsNullOrWhiteSpace(ViewData["title"] as string) ? ViewData.ModelMetadata.DisplayName : ViewData["title"])
             @if (!string.IsNullOrWhiteSpace(tooltipText))
             {
@@ -113,12 +126,7 @@
         </legend>
 
         @{
-            var fullFieldId = ViewData.TemplateInfo.GetFullHtmlFieldName(Model?.Label)
-                .Replace(".", "_")
-                .Replace("[", "_")
-                .Replace("]", "_");
-
-            if (fullFieldId != string.Empty && !string.Concat(legendPrefix, ViewData.ModelMetadata.PropertyName).Equals(fullFieldId))
+            if (fullFieldId != string.Empty && !legendId.Equals(fullFieldId))
             {
                 <div id="@fullFieldId"></div>
             }
@@ -143,8 +151,8 @@
                     linkStateKey = linkStateKey.Replace(".Year", "_Year");
                 }
 
-                if (testStateKey.Equals(ViewData.ModelMetadata.PropertyName, StringComparison.InvariantCultureIgnoreCase) &&
-                    !testStateKey.Equals(ViewData.ModelMetadata.PropertyName, StringComparison.InvariantCulture))
+                if (testStateKey.Equals(fullFieldId, StringComparison.InvariantCultureIgnoreCase) &&
+                    !testStateKey.Equals(fullFieldId, StringComparison.InvariantCulture))
                 {
                     <div id="@linkStateKey"></div>
                 }
@@ -155,11 +163,11 @@
         {
             if (dateHint != string.Empty)
             {
-                <p class="govuk-hint" id="@legendPrefix@ViewData.ModelMetadata.PropertyName-hint">For example, @dateHint</p>
+                <p class="govuk-hint" id="@legendId-hint">For example, @dateHint</p>
             }
             else
             {
-                <p class="govuk-hint" id="@legendPrefix@ViewData.ModelMetadata.PropertyName-hint">For example, 20 03 2003</p>
+                <p class="govuk-hint" id="@legendId-hint">For example, 20 03 2003</p>
             }
         }
 
@@ -170,7 +178,7 @@
             </div>
         }
 
-        <span id="@ViewData.ModelMetadata.PropertyName-errors">
+        <span id="@legendId-errors">
             @{
                 var errContent = new List<MvcHtmlString>
                     {
@@ -180,10 +188,10 @@
                 Html.ValidationMessageFor(x => x.Year, null, new {@class = "govuk-error-message"})
             };
 
-                if (!Html.ViewData.ModelState.ContainsKey(ViewData.ModelMetadata.PropertyName) ||
-                        !Html.ViewData.ModelState[ViewData.ModelMetadata.PropertyName].Errors.Any())
+                if (!Html.ViewData.ModelState.ContainsKey(fullFieldId) ||
+                        !Html.ViewData.ModelState[fullFieldId].Errors.Any())
                 {
-                    errContent.Insert(0, Html.ValidationMessageNested(ViewData.ModelMetadata.PropertyName));
+                    errContent.Insert(0, Html.ValidationMessageNested(fullFieldId));
                 }
 
                 var enumerable = errContent.Select(x => x?.ToHtmlString());

--- a/Web/Edubase.Web.UI/Views/Shared/_ValidationSummary.cshtml
+++ b/Web/Edubase.Web.UI/Views/Shared/_ValidationSummary.cshtml
@@ -24,11 +24,9 @@
                         // traditional model validation
                         foreach (var modelError in Model.Keys.SelectMany(key => this.Model[key].Errors.Select(x => Tuple.Create(key, x.ErrorMessage))))
                         {
-                            var splitName = Regex.Replace(@modelError.Item2, "([a-z])([A-Z])", "$1 $2");
-                            splitName = splitName.Substring(0, 1) + splitName.Substring(1).ToLower();
                             <li>
                                  <a id="error-summary-@StringUtils.ElementIdFormat(@modelError.Item1)-list-item" href='#@modelError.Item1.Replace(".", "_").Replace("[", "_").Replace("]", "_")'>
-                                    @Html.HtmlNewlines(@splitName)
+                                    @Html.HtmlNewlines(@modelError.Item2)
                                  </a>
                             </li>
                         }

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
@@ -66,7 +66,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
                 .WithErrorMessage("Required")
-                .WithCustomState("You must select a governor");
+                .WithCustomState("Select a governor");
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Governors)
                 .WithErrorMessage("Required")
-                .WithCustomState("At least one governor must be selected");
+                .WithCustomState("Select at least one governor");
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Governors)
                 .WithErrorMessage("Required")
-                .WithCustomState("At least one governor must be selected");
+                .WithCustomState("Select at least one governor");
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
                 .WithErrorMessage("Required")
-                .WithCustomState("You must select a governor");
+                .WithCustomState("Select a governor");
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldHaveValidationErrorFor(x => x.Governors)
                 .WithErrorMessage("Required")
-                .WithCustomState("At least one governor must be selected");
+                .WithCustomState("Select at least one governor");
         }
 
         [Fact]

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
@@ -21,10 +21,8 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
         private readonly DateTimeViewModel _arbitraryInvalidStartDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
         private readonly DateTimeViewModel _arbitraryInvalidEndDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
 
-
-
         [Fact]
-        public void SinglePersonRole__SelectedGovernorId__WhenNull__And__GovernorsList_Empty__Then__GovernorId_ValidationError()
+        public void SinglePersonRole_SelectedGovernorId_WhenNull_ThenError()
         {
             // Arrange
             var model = new SelectSharedGovernorViewModel
@@ -43,7 +41,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
         }
 
         [Fact]
-        public void SinglePersonRole__SelectedGovernorId__WhenNull__And__GovernorsList_NoneSelected__Then__GovernorId_ValidationError()
+        public void SinglePersonRole_SelectedGovernorId_WhenNoGovernorSelected_ThenError()
         {
             // Arrange
             var model = new SelectSharedGovernorViewModel
@@ -72,7 +70,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
         }
 
         [Fact]
-        public void ShouldHaveValidationErrorWhenNoSelectedGovernorForMultiRole()
+        public void MultiPersonRole_Governors_WhenNoGovernorSelected_ThenError()
         {
             // Arrange
             var model = new SelectSharedGovernorViewModel
@@ -88,20 +86,20 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                         AppointmentEndDate = new DateTimeViewModel()
                     }
                 },
-                Role = ArbitrarySinglePersonRole,
+                Role = ArbitraryMultiPersonRole,
             };
 
             // Act
             var result = _validator.TestValidate(model);
 
             // Assert
-            result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
+            result.ShouldHaveValidationErrorFor(x => x.Governors)
                 .WithErrorMessage("Required")
-                .WithCustomState("You must select a governor");
+                .WithCustomState("At least one governor must be selected");
         }
 
         [Fact]
-        public void ShouldNotHaveValidationErrorWhenRequiredFieldsAreValidForSingularRole()
+        public void SinglePersonRole_SelectedGovernorId_WhenValid_NoError()
         {
             // Arrange
             var model = new SelectSharedGovernorViewModel
@@ -128,7 +126,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
         }
 
         [Fact]
-        public void ShouldNotHaveValidationErrorWhenRequiredFieldsAreValidForMultiRole()
+        public void MultiPersonRole_Governors_WhenValid_NoError()
         {
             // Arrange
             var model = new SelectSharedGovernorViewModel
@@ -143,6 +141,148 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                         AppointmentStartDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 },
                         AppointmentEndDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2025 }
                     }
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Governors);
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenInvalid_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null, // Not applicable for multi roles
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = false,
+                        AppointmentStartDate = _arbitraryInvalidStartDate // Invalid entry
+                    }
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Governors)
+                .WithErrorMessage("Required")
+                .WithCustomState("At least one governor must be selected");
+        }
+
+        [Fact]
+        public void SinglePersonRole_SelectedGovernorId_WhenMultipleGovernorsButNoneSelected_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel { Id = 1, Selected = false },
+                    new SharedGovernorViewModel { Id = 2, Selected = false },
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
+                .WithErrorMessage("Required")
+                .WithCustomState("You must select a governor");
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsButNoneSelected_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel { Id = 1, Selected = false },
+                    new SharedGovernorViewModel { Id = 2, Selected = false },
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Governors)
+                .WithErrorMessage("Required")
+                .WithCustomState("At least one governor must be selected");
+        }
+
+        [Fact]
+        public void SinglePersonRole_SelectedGovernorId_WhenMultipleGovernorsAndOneSelected_NoError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = "2",
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel { Id = 1, Selected = false, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel { Id = 2, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.SelectedGovernorId);
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsAndOneSelected_NoError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel { Id = 1, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel { Id = 2, Selected = false, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Governors);
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsAndMultipleSelected_NoError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel { Id = 1, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel { Id = 2, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
                 },
                 Role = ArbitraryMultiPersonRole,
             };

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using Edubase.Services.Enums;
+using Edubase.Web.UI.Areas.Governors.Models;
+using Edubase.Web.UI.Areas.Governors.Models.Validators;
+using Edubase.Web.UI.Models;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
+{
+    public class SelectSharedGovernorViewModelValidatorTests
+    {
+        private readonly SelectSharedGovernorViewModelValidator _validator = new SelectSharedGovernorViewModelValidator();
+
+        private const eLookupGovernorRole ArbitrarySinglePersonRole = eLookupGovernorRole.ChairOfGovernors;
+        private const eLookupGovernorRole ArbitraryMultiPersonRole = eLookupGovernorRole.Governor;
+
+        private readonly DateTimeViewModel _arbitraryValidStartDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 };
+        private readonly DateTimeViewModel _arbitraryValidEndDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2055 };
+
+        private readonly DateTimeViewModel _arbitraryInvalidStartDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
+        private readonly DateTimeViewModel _arbitraryInvalidEndDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
+
+
+
+        [Fact]
+        public void SinglePersonRole__SelectedGovernorId__WhenNull__And__GovernorsList_Empty__Then__GovernorId_ValidationError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>(), // No governors
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
+                .WithErrorMessage("Required");
+        }
+
+        [Fact]
+        public void SinglePersonRole__SelectedGovernorId__WhenNull__And__GovernorsList_NoneSelected__Then__GovernorId_ValidationError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null, // Invalid scenario
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = false,
+                        AppointmentStartDate = new DateTimeViewModel(),
+                        AppointmentEndDate = new DateTimeViewModel()
+                    }
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
+                .WithErrorMessage("Required")
+                .WithCustomState("You must select a governor");
+        }
+
+        [Fact]
+        public void ShouldHaveValidationErrorWhenNoSelectedGovernorForMultiRole()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null, // Not applicable for multi roles
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = false,
+                        AppointmentStartDate = new DateTimeViewModel(),
+                        AppointmentEndDate = new DateTimeViewModel()
+                    }
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SelectedGovernorId)
+                .WithErrorMessage("Required")
+                .WithCustomState("You must select a governor");
+        }
+
+        [Fact]
+        public void ShouldNotHaveValidationErrorWhenRequiredFieldsAreValidForSingularRole()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = "1",
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = true,
+                        AppointmentStartDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 },
+                        AppointmentEndDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2025 }
+                    }
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.SelectedGovernorId);
+        }
+
+        [Fact]
+        public void ShouldNotHaveValidationErrorWhenRequiredFieldsAreValidForMultiRole()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null, // Not applicable for multi roles
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = true,
+                        AppointmentStartDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 },
+                        AppointmentEndDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2025 }
+                    }
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Governors);
+        }
+    }
+}

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/SelectSharedGovernorViewModelValidatorTests.cs
@@ -10,16 +10,23 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
 {
     public class SelectSharedGovernorViewModelValidatorTests
     {
-        private readonly SelectSharedGovernorViewModelValidator _validator = new SelectSharedGovernorViewModelValidator();
+        private readonly SelectSharedGovernorViewModelValidator _validator =
+            new SelectSharedGovernorViewModelValidator();
 
         private const eLookupGovernorRole ArbitrarySinglePersonRole = eLookupGovernorRole.ChairOfGovernors;
         private const eLookupGovernorRole ArbitraryMultiPersonRole = eLookupGovernorRole.Governor;
 
-        private readonly DateTimeViewModel _arbitraryValidStartDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 };
-        private readonly DateTimeViewModel _arbitraryValidEndDate = new DateTimeViewModel { Day = 1, Month = 1, Year = 2055 };
+        private readonly DateTimeViewModel _arbitraryValidStartDate =
+            new DateTimeViewModel { Day = 1, Month = 1, Year = 2020 };
 
-        private readonly DateTimeViewModel _arbitraryInvalidStartDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
-        private readonly DateTimeViewModel _arbitraryInvalidEndDate = new DateTimeViewModel { Day = 50, Month = 20, Year = null };
+        private readonly DateTimeViewModel _arbitraryValidEndDate =
+            new DateTimeViewModel { Day = 1, Month = 1, Year = 2055 };
+
+        private readonly DateTimeViewModel _arbitraryInvalidStartDate =
+            new DateTimeViewModel { Day = 50, Month = 20, Year = null };
+
+        private readonly DateTimeViewModel _arbitraryInvalidEndDate =
+            new DateTimeViewModel { Day = 50, Month = 20, Year = null };
 
         [Fact]
         public void SinglePersonRole_SelectedGovernorId_WhenNull_ThenError()
@@ -163,9 +170,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 {
                     new SharedGovernorViewModel
                     {
-                        Id = 1,
-                        Selected = false,
-                        AppointmentStartDate = _arbitraryInvalidStartDate // Invalid entry
+                        Id = 1, Selected = false, AppointmentStartDate = _arbitraryInvalidStartDate // Invalid entry
                     }
                 },
                 Role = ArbitraryMultiPersonRole,
@@ -237,8 +242,56 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 SelectedGovernorId = "2",
                 Governors = new List<SharedGovernorViewModel>
                 {
-                    new SharedGovernorViewModel { Id = 1, Selected = false, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
-                    new SharedGovernorViewModel { Id = 2, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = false,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.SelectedGovernorId);
+        }
+
+        [Fact]
+        public void
+            SinglePersonRole_SelectedGovernorId_WhenMultipleGovernorsAndOneSelected__And_MismatchWithSelected__NoError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId =
+                    "1", // Note for single role, only this is used and the `Selected` property is disregarded.
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = false,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
                 },
                 Role = ArbitrarySinglePersonRole,
             };
@@ -259,8 +312,20 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 SelectedGovernorId = null,
                 Governors = new List<SharedGovernorViewModel>
                 {
-                    new SharedGovernorViewModel { Id = 1, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
-                    new SharedGovernorViewModel { Id = 2, Selected = false, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        Selected = false,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
                 },
                 Role = ArbitraryMultiPersonRole,
             };
@@ -281,8 +346,20 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 SelectedGovernorId = null,
                 Governors = new List<SharedGovernorViewModel>
                 {
-                    new SharedGovernorViewModel { Id = 1, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
-                    new SharedGovernorViewModel { Id = 2, Selected = true, AppointmentStartDate = _arbitraryValidStartDate, AppointmentEndDate = _arbitraryValidEndDate },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
                 },
                 Role = ArbitraryMultiPersonRole,
             };
@@ -293,5 +370,234 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             result.ShouldNotHaveValidationErrorFor(x => x.Governors);
         }
+
+        [Fact]
+        public void SinglePersonRole_SelectedGovernorId_WhenSelectedGovernorHasInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = "1",
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    }
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name (1)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name (1)");
+        }
+
+        [Fact]
+        public void SinglePersonRole_SelectedGovernorId_WhenMultipleGovernorsAndSelectedGovernorHasInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = "2",
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        FullName = "Governor Name 2",
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    },
+                },
+                Role = ArbitrarySinglePersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name 2 (2)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name 2 (2)");
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenSelectedGovernorHasInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    }
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name (1)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name (1)");
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsAndSelectedGovernorHasInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        Selected = false, // Selected matters for multi roles
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        FullName = "Governor Name 2",
+                        Selected = true, // Selected matters for multi roles
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    },
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name 2 (2)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name 2 (2)");
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsAndMultipleSelectedAndOneHasInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryValidStartDate,
+                        AppointmentEndDate = _arbitraryValidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        FullName = "Governor Name 2",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    },
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name 2 (2)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name 2 (2)");
+        }
+
+        [Fact]
+        public void MultiPersonRole_Governors_WhenMultipleGovernorsAndMultipleSelectedAndAllHaveInvalidDates_ThenError()
+        {
+            // Arrange
+            var model = new SelectSharedGovernorViewModel
+            {
+                SelectedGovernorId = null,
+                Governors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = 1,
+                        FullName = "Governor Name",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    },
+                    new SharedGovernorViewModel
+                    {
+                        Id = 2,
+                        FullName = "Governor Name 2",
+                        Selected = true,
+                        AppointmentStartDate = _arbitraryInvalidStartDate,
+                        AppointmentEndDate = _arbitraryInvalidEndDate
+                    },
+                },
+                Role = ArbitraryMultiPersonRole,
+            };
+
+            // Act
+            var result = _validator.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name (1)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[0].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name (1)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentStartDate)}")
+                .WithErrorMessage("Enter a valid appointment start date for Governor Name 2 (2)");
+
+            result.ShouldHaveValidationErrorFor($"Governors[1].{nameof(SharedGovernorViewModel.AppointmentEndDate)}")
+                .WithErrorMessage("Enter a valid appointment end date for Governor Name 2 (2)");
+        }
+
     }
 }

--- a/Web/Edubase.Web.UIUnitTests/Edubase.Web.UIUnitTests.csproj
+++ b/Web/Edubase.Web.UIUnitTests/Edubase.Web.UIUnitTests.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Faker.Net" Version="2.0.163" />
+    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="FluentValidation.Mvc5" Version="8.6.1" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.18.2" />


### PR DESCRIPTION
Per UAT, the end date is now optional for this role.

- **Requirements that the _shared governance professional - establishment_ should have an optional end date:**
  - ![image](https://github.com/user-attachments/assets/4e59a397-6596-45f9-ae57-180a04124ff8)
- **Confirmation that the Java API will accept the submission (i.e., this is a frontend validation only):**
  - ![image](https://github.com/user-attachments/assets/41aac585-37b3-469c-a2ec-53962e813446)
- **Note that error messages coming from the Java API are handled separately/differently, and do not get linked (data being submitted to the API means the C# validations have passed):**
  - ![image](https://github.com/user-attachments/assets/63e2fa20-5033-4feb-b2d8-6bf21a129ab3)



Note that this PR includes some additional fixes while I was working in this area:

- **Selections and inputs are now retained after submit** 
  - (previously, the selected radio button would be cleared on error)
  - ![image](https://github.com/user-attachments/assets/d5513d8c-3a22-4a8f-92d7-cd1a8930715f)
- **Error messages are now linked directly to (and displayed next to) the field(s) they apply to**
  - (previously, a vague error summary would be displayed with no details at the top of the page) 
  - ![image](https://github.com/user-attachments/assets/378602bb-7245-47df-8731-b23922281c50)
- **Error messages are no longer dropped/deduplicated**
  - (previously, multiple error messages would be combined/folded together when they should be listed separately -- for example, if the start date is missing for multiple selected shared governors then only one error message about the start date missing would display, or if one out of 20+ selected governors has the date missing it would not link to the single governor this error applies to)
  - ![image](https://github.com/user-attachments/assets/689117d9-d36a-4391-af37-c06b45f820ad)
