### PR TITLE
Hide the Ofsted fields from the bulk update guidance.

### DIFF
--- a/Web/Edubase.Web.UI/Views/Guidance/EstablishmentBulkUpdate.cshtml
+++ b/Web/Edubase.Web.UI/Views/Guidance/EstablishmentBulkUpdate.cshtml
@@ -1,3 +1,4 @@
+@using System.Configuration
 @{
     ViewBag.Title = "Get Information about Schools";
     ViewBag.imageMQ = "(max-width: 768px)";
@@ -277,18 +278,22 @@
                 <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">TelephoneNum</td>
                 <td class="govuk-table__cell" data-label="Equivalent field name in app">Telephone</td>
             </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">OfstedRating</td>
-                <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted rating</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">OfstedLastInspection</td>
-                <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted last inspection</td>
-            </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">Osted report link</td>
-                <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted report link</td>
-            </tr>
+
+            @if("true".Equals(ConfigurationManager.AppSettings["Feature_Ofsted_ShowBulkUpdateGuidance"], StringComparison.OrdinalIgnoreCase)) {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">OfstedRating</td>
+                    <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted rating</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">OfstedLastInspection</td>
+                    <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted last inspection</td>
+                </tr>
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">Osted report link</td>
+                    <td class="govuk-table__cell" data-label="Equivalent field name in app">Ofsted report link</td>
+                </tr>
+            }
+
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">Inspectorate</td>
                 <td class="govuk-table__cell" data-label="Equivalent field name in app">Inspectorate</td>
@@ -550,10 +555,15 @@
                 <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">DateofLastFullBridgeInspection</td>
                 <td class="govuk-table__cell" data-label="Equivalent field name in app">Date of the Last Bridge Visit</td>
             </tr>
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">DateofLastFullOfstedInspection</td>
-                <td class="govuk-table__cell" data-label="Equivalent field name in app">Date of the Last Ofsted Visit</td>
-            </tr>
+
+            @if("true".Equals(ConfigurationManager.AppSettings["Feature_Ofsted_ShowBulkUpdateGuidance"], StringComparison.OrdinalIgnoreCase))
+            {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">DateofLastFullOfstedInspection</td>
+                    <td class="govuk-table__cell" data-label="Equivalent field name in app">Date of the Last Ofsted Visit</td>
+                </tr>
+            }
+
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell" data-label="Database name (use this for your upload file)">DateofLastFullISIInspection</td>
                 <td class="govuk-table__cell" data-label="Equivalent field name in app">Date of the Last ISI Visit</td>

--- a/Web/Edubase.Web.UI/Web.config
+++ b/Web/Edubase.Web.UI/Web.config
@@ -266,6 +266,16 @@
     <add key="FscpdCacheHours" value="72" />
     <add key="FscpdUsername" value="" />
     <add key="FscpdPassword" value="" />
+
+
+    <!--
+      #232199 / #232608: Feature flag, to optionally hide/display the Ofsted fields in the bulk update guidance.
+      - A value of `true` will display the Ofsted fields within the bulk update guidance
+      - Any other value will hide them.
+    -->
+    <add key="Feature_Ofsted_ShowBulkUpdateGuidance" value="true" />
+
+
     <add key="OSPlacesUrl" value="https://api.os.uk/" />
     <add key="AzureMapsUrl" value="https://atlas.microsoft.com" />
     <!-- ==== WEBSITE AUTHENTICATION / AUTHORISATION ==== -->


### PR DESCRIPTION
**Background**

Per recent changes within Ofsted, inspection results are moving away from a single rating to a different system.

While this is being finalised, we will no longer accept updates to Ofsted-related fields via bulk-update. As a result, these fields will be removed from the guidance.

**Changes made**

- This pull request introduces a feature toggle, to optionally hide/show Ofsted-related fields from the bulk-update guidance
  - The default setting is to continue displaying it (current behaviour)

**"Show, don't tell"**

- Feature toggle on (left) / off (right):
  - ![image](https://github.com/user-attachments/assets/b261c2d6-e968-4224-bed1-a5a59b734b48)
  - ![image](https://github.com/user-attachments/assets/f0fc80da-39bc-464d-8ff2-89b270a63f43)