### PR TITLE
Copy updated logic to historic section too

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Governors/Views/Governor/ViewEdit.cshtml
@@ -506,7 +506,7 @@ else
                             if (Model.GovernorPermissions.Update)
                             {
                                 <div class="button-wrapper">
-                                    @if (Model.EstablishmentUrn.HasValue && ((eLookupGovernorRole)row.Model.RoleId == eLookupGovernorRole.Group_SharedLocalGovernor || (eLookupGovernorRole)row.Model.RoleId == eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody))
+                                    @if (Model.EstablishmentUrn.HasValue && row.Model.RoleId.HasValue && EnumSets.SharedGovernorRoles.Contains(row.Model.RoleId.Value))
                                     {
                                         @Html.RouteLink("Edit person", "EditSharedGovernor", new { establishmentUrn = Model.EstablishmentUrn, governorId = row.Model.Id }, new { @class = "govuk-button govuk-button--secondary" })
                                     }


### PR DESCRIPTION
The logic to include additional types of "shared governor" was previously updated for the "current" governor buttons, but it looks like the "historical" governor section was missed.

This PR resolves this.