### PR TITLE
Add a "details" section explaining why GIAS no longer displays Ofsted ratings

### DIFF
--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
@@ -227,20 +227,32 @@
                     }
                 }
             }
-            else
-            {
-                // TODO: Update this once the content is agreed in #232329.
-                newlineRequired = true;
-                <span>GIAS no longer displays Ofsted inspection ratings</span>
-            }
 
             @if (newlineRequired)
             {
                 <br/>
             }
-            <a href="@Model.OfstedReportUrl" target="_blank" rel="noreferrer noopener">
-                Ofsted report (opens in new tab)
-            </a>
+
+            <div class="govuk-!-margin-bottom-3">
+                <a href="@Model.OfstedReportUrl" target="_blank" rel="noreferrer noopener">
+                    Ofsted report (opens in new tab)
+                </a>
+            </div>
+
+            @if (!Model.ShowOfstedRatings)
+            {
+                <div>GIAS no longer displays Ofsted inspection ratings</div>
+                <details class="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                            Why the rating is not displayed
+                        </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        From September 2024, Ofsted no longer makes an overall effectiveness judgement in inspections of state-funded schools.
+                    </div>
+                </details>
+            }
         </dd>
     </div>
 }

--- a/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
+++ b/Web/Edubase.Web.UI/Areas/Establishments/Views/Establishment/Partials/Header.cshtml
@@ -241,7 +241,6 @@
 
             @if (!Model.ShowOfstedRatings)
             {
-                <div>GIAS no longer displays Ofsted inspection ratings</div>
                 <details class="govuk-details">
                     <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">


### PR DESCRIPTION
#232329

The details section text is as-provided. 

Note that without the margin override, the link to the report and the clickable details link are too close together.


![image](https://github.com/user-attachments/assets/5a925492-bed3-4db2-9008-f0fa1e6fdcde)

