### PR TITLE
296872 Potential fix for code scanning alert no. 14: Incomplete string escaping or encoding

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasHelpers/QueryString.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasHelpers/QueryString.js
@@ -2,7 +2,7 @@ const QueryString = function(name, url) {
   if(!url){
     url = window.location.href;
   }
-  name = name.replace(/[\[\]]/g, "\\$&");
+  name = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)", "i");
   const results = regex.exec(url);
 


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/14](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/14)

Generally, to fix this kind of issue when interpolating arbitrary strings into a regular expression, you should fully escape all regex metacharacters in the input (including backslash), or avoid string-based `RegExp` construction altogether. A common pattern is to define a small helper function like `escapeRegExp` that replaces all special characters with escaped versions using a global regex replacement.

For this specific code, the best minimal fix is to replace the ad-hoc `name.replace(/[\[\]]/g, "\\$&");` with a more complete escaping step, e.g. `name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");`. This is the standard pattern recommended by MDN for escaping user-provided strings for use in a regular expression. It ensures that any metacharacter, including backslash, is treated as literal text. You only need to change line 5 in `Web/Edubase.Web.UI/Assets/Scripts/GiasHelpers/QueryString.js`; no additional imports or functions are strictly necessary because the fix can be done inline with a single `replace` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
