### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasDownloadFilters.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasDownloadFilters.js
@@ -108,9 +108,9 @@ const GiasDownloadFilters = {
         resultsContainer.html(data);
 
         if (resultsContainer.find('#no-downloads-available').length !== 0) {
-          pageBanner.html(GiasDownloadFilters.bannerDefaultText);
+          pageBanner.text(GiasDownloadFilters.bannerDefaultText);
         } else {
-          pageBanner.html("Files available to download from " + parseInt($('#FilterDate_Day').val(), 10) + " " + monthNames[$('#FilterDate_Month').val() - 1] + " " + $('#FilterDate_Year').val());
+          pageBanner.text("Files available to download from " + parseInt($('#FilterDate_Day').val(), 10) + " " + monthNames[$('#FilterDate_Month').val() - 1] + " " + $('#FilterDate_Year').val());
         }
 
         resultsContainer.removeClass('pending-results-update');


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/13](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/13)

In general, the fix is to avoid reinterpreting DOM text as HTML. Whenever you construct a message using values from form fields or other potentially tainted DOM locations, assign it via a text-only API (`text()` in jQuery, `textContent` in the DOM) or escape it before using `html()`.

For this specific code, the banner text on line 111/113 does not need to contain HTML markup; it is just a sentence. The safest and simplest fix without changing visible behaviour is to use `pageBanner.text(...)` instead of `pageBanner.html(...)` for both branches. This ensures that whatever string is constructed is treated as plain text and not parsed as HTML, eliminating the XSS risk while preserving the displayed content. No additional imports or helpers are needed; jQuery is already in use elsewhere in the file.

Concretely:
- In `GiasDownloadFilters.getResults`, locate the success callback where `pageBanner.html(...)` is called at lines 111 and 113.
- Replace `pageBanner.html(GiasDownloadFilters.bannerDefaultText);` with `pageBanner.text(GiasDownloadFilters.bannerDefaultText);`.
- Replace `pageBanner.html("Files available to download from " + ...);` with `pageBanner.text("Files available to download from " + ...);`.
- Leave other `.html()` calls (such as those writing known-safe markup like the spinner) unchanged, since they are not part of this tainted flow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
