### PR TITLE
297599 Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js
@@ -181,7 +181,7 @@ class GiasSearchMap {
       $('#results-container').removeClass('hidden');
       $('#option-select-sort-by').removeClass('hidden');
       const count = $('#list-count').text();
-      this.$resultsNotification.html('Search results loaded. Showing ' + count + ' establishments in list view.');
+      this.$resultsNotification.text('Search results loaded. Showing ' + count + ' establishments in list view.');
       this.config.currentView = 'list';
     });
 


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/10](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/10)

In general, to fix this type of problem you must avoid taking text from the DOM and feeding it directly into APIs that interpret it as HTML (such as `innerHTML` or jQuery’s `.html()`) without proper encoding. Instead, either (a) use text-only APIs like `textContent` / jQuery `.text()` so the browser never treats the content as HTML, or (b) carefully HTML-encode/escape any dynamic parts before insertion and still ensure they are not treated as executable code.

For this specific case in `Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js`, the best fix without changing functionality is to replace the use of `.html()` with `.text()` when writing the results notification. The content is a plain language sentence with an embedded count; it does not rely on any HTML markup. Using `.text()` will render the entire string as literal text, preventing any HTML interpretation of `count` or the surrounding text. This keeps the same user-visible message while eliminating the risk that an attacker-controlled `#list-count` text could inject markup or scripts.

Concretely:
- In the `bindActions()` method, in the `#view-list` click handler, change line 184 from:
  - `this.$resultsNotification.html('Search results loaded. Showing ' + count + ' establishments in list view.');`
- To:
  - `this.$resultsNotification.text('Search results loaded. Showing ' + count + ' establishments in list view.');`

No new methods or complex logic are needed; jQuery is already in use, and `.text()` is part of its standard API. No imports or additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
