### PR TITLE
297598 Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasFilterToggle.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasFilterToggle.js
@@ -24,10 +24,12 @@ class GiasFilterToggle {
             <div class="gias-mobile-filters__footer">
                 <button class="govuk-button gias-mobile-filters__close" id="gias-mobile-filter-submit">
                     View results
-                    <span class="mobile-count">(${startingCount})</span>
+                    <span class="mobile-count"></span>
                 </button>
             </div>
         </div>`);
+
+    mobileFiltersContainer.find('.mobile-count').text(`(${startingCount})`);
 
     mobileFilters.detach().appendTo(mobileFiltersContainer.find('.gias-mobile-filters__panel'));
 


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/12](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/12)

In general, the problem is caused by taking text from the DOM (`$('#list-count').text()`), then interpolating it directly into an HTML string that is parsed as HTML by jQuery. To fix this, we must ensure the interpolated value is safe before it becomes part of the HTML source. The two common approaches are: (1) encode/escape the value so that any HTML meta-characters are rendered as text, or (2) avoid constructing that part of the DOM via an HTML string and instead insert the dynamic value via DOM APIs or jQuery’s `.text()` after the structure is created.

The most robust, minimal-change fix here is: build the mobile filter container’s HTML without inserting `startingCount` directly, and then, once the container exists in the DOM, set the text content of the `.mobile-count` span via `.text(startingCount)`. jQuery’s `.text()` safely treats the string as text, not HTML, so even if `startingCount` contains `<` or `&`, they will be escaped in the rendered page. Concretely, in `Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasFilterToggle.js`, change the template literal on lines 15–30 so that the span initially has no dynamic content (e.g., `(<span class="mobile-count"></span>)` or similar), and then, immediately after creating `mobileFiltersContainer`, call `mobileFiltersContainer.find('.mobile-count').text(startingCount);`. No new imports or methods are needed; this uses existing jQuery.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
