### PR TITLE
297600 Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js
@@ -79,7 +79,7 @@ class GiasSearchMap {
         window.setTimeout(function () {
           $('.map-header').removeClass('loading');
           const count = $('#map-count').text();
-          self.$resultsNotification.html('Search results loaded. Showing ' + count + ' establishments in map view.');
+          self.$resultsNotification.text('Search results loaded. Showing ' + count + ' establishments in map view.');
         }, 1500);
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/9](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/9)

General fix: avoid taking text from the DOM and then writing it back as HTML; instead, either (a) continue to treat it as text by using `.text()` or equivalent, or (b) HTML-encode/escape before writing with `.html()`. Since the notification content is plain text, the simplest, non‑breaking change is to switch from `.html()` to `.text()` so that `count` is always treated as literal text, not markup.

Best concrete fix here: in `Web/Edubase.Web.UI/Assets/Scripts/GiasModules/GiasSearchMap.js`, inside `pointsLoaded()` in `getSearchData()`, replace `self.$resultsNotification.html('Search results loaded. Showing ' + count + ' establishments in map view.');` with `self.$resultsNotification.text('Search results loaded. Showing ' + count + ' establishments in map view.');`. This preserves the displayed message, continues to allow screen readers and users to see the status text, but guarantees that any meta-characters in `count` are not treated as HTML. No new imports, helpers, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
