### PR TITLE
297605 Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/giasAriaLive.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/giasAriaLive.js
@@ -1,7 +1,7 @@
 const giasAriaLive = function(){
   // Re-inserting text into notification/banner to trigger aria-live
   let $bannerContent = $('.js-trigger-aria-live > .message-text');
-  $bannerContent.html($bannerContent.text());
+  $bannerContent.text($bannerContent.text());
 };
 
 export default giasAriaLive;


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/7](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/7)

In general, the problem is that text extracted from the DOM is then reinserted using an HTML sink (`.html()`), which can cause the text to be interpreted as markup. To fix this, we should use a text-only sink (`.text()`) instead of `.html()`, so the content remains plain text and any metacharacters are not treated as HTML. This maintains the aria-live “change” behavior without changing user-visible content semantics.

The best targeted fix is to modify line 4 in `Web/Edubase.Web.UI/Assets/Scripts/GiasGlobal/giasAriaLive.js` to use `.text()` instead of `.html()`. This keeps the explicit “re-insert” operation (which is presumably needed to trigger the aria-live region) but ensures that the content is treated as text, not HTML. No changes are needed to other lines, and no new imports or helper functions are required, because jQuery is already used and `.text()` is a standard method.

Concretely:
- In `giasAriaLive.js`, replace `$bannerContent.html($bannerContent.text());` with `$bannerContent.text($bannerContent.text());`.
- No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
