### PR TITLE
297606 Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/Entry/independent-schools-sig-search-results.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/Entry/independent-schools-sig-search-results.js
@@ -114,7 +114,8 @@ const _throttle = require('lodash.throttle');
   $('#set-saver').on('click',
     function(e) {
       e.preventDefault();
-      const params = $('#option-select-local-authority').find(':input').serialize() + '&referrer=results&Mode=' + document.getElementById('Mode').value;
+      const modeValue = encodeURIComponent(document.getElementById('Mode').value);
+      const params = $('#option-select-local-authority').find(':input').serialize() + '&referrer=results&Mode=' + modeValue;
       window.location = '/independent-schools/predefined-local-authority-sets/create?' + params;
 
     });


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/6](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/6)

In general, the fix is to ensure that any untrusted data read from the DOM is properly encoded before being incorporated into a URL or any context where it might later be interpreted as HTML or script. For query parameters, this means applying `encodeURIComponent` to each parameter value (and, if needed, to parameter names) instead of concatenating raw `.value` strings.

In this file, the problematic data flow is: building `params` by serializing inputs and then appending `&referrer=results&Mode=` plus `document.getElementById('Mode').value`, and assigning the resulting string to `window.location`. The least‑intrusive, behavior‑preserving fix is to URL‑encode the `Mode` value before concatenation. We should change line 117 so that it computes `const modeValue = encodeURIComponent(document.getElementById('Mode').value);` and then use `modeValue` in the `params` string. This ensures that any special characters or markup in the `Mode` value are safely encoded in the query string and cannot be interpreted as HTML or script if the parameter is later reflected into a page.

No new imports or external libraries are needed; `encodeURIComponent` is a built‑in JavaScript function available in browsers. All other logic (form serialization, redirect URL, event wiring) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
