### PR TITLE
Fix to duplicate historic govs including test

### DIFF
--- a/Web/Edubase.Services/Governors/Models/GovernorModel.cs
+++ b/Web/Edubase.Services/Governors/Models/GovernorModel.cs
@@ -2,9 +2,6 @@ using Edubase.Common;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Edubase.Services.Governors.Models
 {

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -113,48 +113,13 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             //this allows roles that are not valid but exist to be displayed
             var allRoles = dto.ApplicableRoles.Union(governors.Select(g => (GR) g.RoleId).Distinct());
 
-            var roles = allRoles.Where(role =>
-            {
-                if (!EnumSets.eSharedGovernorRoles.Contains(role))
-                {
-                    return true;
-                }
-                var localEquivalent = RoleEquivalence.GetLocalEquivalentToSharedRole(role);
-                if (localEquivalent != null)
-                {
-                    if (!dto.ApplicableRoles.Contains(localEquivalent.Value) || role == GR.Establishment_SharedGovernanceProfessional)
-                    {
-                        return true;
-                    }
-                }
-                return false;
-            }).ToList();
-
-            // PATCH: De-duplicate equivalent roles but pick a representative that HAS a display policy.
-            // This avoids null displayPolicy when the local role lacks a policy but a shared variant has one.
-            roles = roles
-                .GroupBy(r => RoleEquivalence.GetLocalEquivalentToSharedRole(r) ?? r) 
-                .Select(g =>
-                {
-                    var localKey = g.Key;
-
-                    // All roles in the "family" (e.g., Local + Shared variants)
-                    var family = RoleEquivalence.GetEquivalentToLocalRole(localKey).ToList();
-
-                    // Prefer Local over Shared, but ONLY if a policy exists for it; otherwise fall back to a shared variant that has a policy.
-                    var orderedFamily = family
-                        .OrderBy(r => GetFamilyRolePriority(r, localKey))
-                            .ToList();
-
-                    var representative = orderedFamily.FirstOrDefault(r => dto.RoleDisplayPolicies.ContainsKey(r));
-                    return representative.Equals(default(eLookupGovernorRole)) ? localKey : representative;
-                })
+            var roles = dto.ApplicableRoles
+                .Union(governors.Select(g => (GR) g.RoleId).Distinct())
                 .Distinct()
                 .ToList();
 
             foreach (var role in roles)
             {
-                var equivalentRoles = RoleEquivalence.GetEquivalentToLocalRole(role).Cast<int>().ToList();
                 var shouldPluralise = !EnumSets.eSingularGovernorRoles.Contains(role);
 
                 var governorRoleNameTitle = GovernorRoleNameFactory.Create(
@@ -191,25 +156,10 @@ namespace Edubase.Web.UI.Areas.Governors.Models
 
 
                 var list = governors
-                    .Where(x => x.RoleId.HasValue && equivalentRoles.Contains(x.RoleId.Value));
-
-                // PATCH: De-duplicate rows that represent the same person across local/shared equivalents
-                var deduped = list
-                    .GroupBy(g => new
-                    {
-                        First = (g.Person_FirstName ?? string.Empty).Trim(),
-                        Middle = (g.Person_MiddleName ?? string.Empty).Trim(),
-                        Last = (g.Person_LastName ?? string.Empty).Trim(),
-                        Dob = g.DOB
-                    })
-                    .Select(grp =>
-                        // Prefer LocalGovernor over shared variants; then Group_SharedLocalGovernor; then Establishment_SharedLocalGovernor.
-                        grp.OrderBy(x => GetRolePriority(x.RoleId.Value)).First()
-                    )
+                    .Where(x => x.RoleId == (int) role)
                     .ToList();
 
-                // Use the deduped list from here on:
-                foreach (var governor in deduped)
+                foreach (var governor in list)
                 {
                     var isShared = governor.RoleId.HasValue && EnumSets.SharedGovernorRoles.Contains(governor.RoleId.Value);
                     var establishments = string.Join(
@@ -218,6 +168,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     );
 
                     GovernorAppointment appointment;
+
                     try
                     {
                         appointment = governor.Appointments?
@@ -233,7 +184,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     var startDate = isShared && appointment != null
                         ? appointment.AppointmentStartDate
                         : governor.AppointmentStartDate;
-
                     var endDate = isShared && appointment != null
                         ? appointment.AppointmentEndDate
                         : governor.AppointmentEndDate;
@@ -298,7 +248,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                         HistoricGovernors.Add(gov);
                     }
                 }
-
 
                 grid.Rows = grid.Rows
                     .OrderByDescending(x => x.SortValue)
@@ -418,28 +367,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             var fullNameWithTitle = StringUtil.ConcatNonEmpties(" ", titleName, governor.GetFullName());
 
             return fullNameWithTitle;
-        }
-
-        private int GetRolePriority(int roleId)
-        {
-            var role = (GR) roleId;
-
-            if (role == GR.LocalGovernor) return 0;
-            if (role == GR.Group_SharedLocalGovernor) return 1;
-            if (role == GR.Establishment_SharedLocalGovernor) return 2;
-
-            return 3; // fallback
-        }
-
-        private int GetFamilyRolePriority(eLookupGovernorRole role, eLookupGovernorRole localKey)
-        {
-            if (role == localKey)
-                return 0;
-
-            if (EnumSets.eSharedGovernorRoles.Contains(role))
-                return 1;
-
-            return 2;
         }
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -133,7 +133,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             // PATCH: De-duplicate equivalent roles but pick a representative that HAS a display policy.
             // This avoids null displayPolicy when the local role lacks a policy but a shared variant has one.
             roles = roles
-                .GroupBy(r => RoleEquivalence.GetLocalEquivalentToSharedRole(r) ?? r)   // family key (normalize shared -> local)
+                .GroupBy(r => RoleEquivalence.GetLocalEquivalentToSharedRole(r) ?? r) 
                 .Select(g =>
                 {
                     var localKey = g.Key;
@@ -142,10 +142,9 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     var family = RoleEquivalence.GetEquivalentToLocalRole(localKey).ToList();
 
                     // Prefer Local over Shared, but ONLY if a policy exists for it; otherwise fall back to a shared variant that has a policy.
-                    var orderedFamily = family.OrderBy(r =>
-                        r.Equals(localKey) ? 0 :
-                        (EnumSets.eSharedGovernorRoles.Contains(r) ? 1 : 2)
-                    ).ToList();
+                    var orderedFamily = family
+                        .OrderBy(r => GetFamilyRolePriority(r, localKey))
+                            .ToList();
 
                     var representative = orderedFamily.FirstOrDefault(r => dto.RoleDisplayPolicies.ContainsKey(r));
                     return representative.Equals(default(eLookupGovernorRole)) ? localKey : representative;
@@ -199,16 +198,13 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     .GroupBy(g => new
                     {
                         First = (g.Person_FirstName ?? string.Empty).Trim(),
+                        Middle = (g.Person_MiddleName ?? string.Empty).Trim(),
                         Last = (g.Person_LastName ?? string.Empty).Trim(),
                         Dob = g.DOB
                     })
                     .Select(grp =>
                         // Prefer LocalGovernor over shared variants; then Group_SharedLocalGovernor; then Establishment_SharedLocalGovernor.
-                        grp.OrderBy(x =>
-                            x.RoleId == (int) GR.LocalGovernor ? 0 :
-                            x.RoleId == (int) GR.Group_SharedLocalGovernor ? 1 :
-                            x.RoleId == (int) GR.Establishment_SharedLocalGovernor ? 2 : 3
-                        ).First()
+                        grp.OrderBy(x => GetRolePriority(x.RoleId.Value)).First()
                     )
                     .ToList();
 
@@ -218,7 +214,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     var isShared = governor.RoleId.HasValue && EnumSets.SharedGovernorRoles.Contains(governor.RoleId.Value);
                     var establishments = string.Join(
                         ", ",
-                        (governor.Appointments?.Select(a => $"{a.EstablishmentName}, URN: {a.EstablishmentUrn}") ?? new string[] { })
+                        governor.Appointments?.Select(a => $"{a.EstablishmentName}, URN: {a.EstablishmentUrn}") ?? new string[] { }
                     );
 
                     GovernorAppointment appointment;
@@ -422,6 +418,28 @@ namespace Edubase.Web.UI.Areas.Governors.Models
             var fullNameWithTitle = StringUtil.ConcatNonEmpties(" ", titleName, governor.GetFullName());
 
             return fullNameWithTitle;
+        }
+
+        private int GetRolePriority(int roleId)
+        {
+            var role = (GR) roleId;
+
+            if (role == GR.LocalGovernor) return 0;
+            if (role == GR.Group_SharedLocalGovernor) return 1;
+            if (role == GR.Establishment_SharedLocalGovernor) return 2;
+
+            return 3; // fallback
+        }
+
+        private int GetFamilyRolePriority(eLookupGovernorRole role, eLookupGovernorRole localKey)
+        {
+            if (role == localKey)
+                return 0;
+
+            if (EnumSets.eSharedGovernorRoles.Contains(role))
+                return 1;
+
+            return 2;
         }
     }
 }

--- a/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
+++ b/Web/Edubase.Web.UI/Areas/Governors/Models/GovernorsGridViewModel.cs
@@ -130,6 +130,29 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                 return false;
             }).ToList();
 
+            // PATCH: De-duplicate equivalent roles but pick a representative that HAS a display policy.
+            // This avoids null displayPolicy when the local role lacks a policy but a shared variant has one.
+            roles = roles
+                .GroupBy(r => RoleEquivalence.GetLocalEquivalentToSharedRole(r) ?? r)   // family key (normalize shared -> local)
+                .Select(g =>
+                {
+                    var localKey = g.Key;
+
+                    // All roles in the "family" (e.g., Local + Shared variants)
+                    var family = RoleEquivalence.GetEquivalentToLocalRole(localKey).ToList();
+
+                    // Prefer Local over Shared, but ONLY if a policy exists for it; otherwise fall back to a shared variant that has a policy.
+                    var orderedFamily = family.OrderBy(r =>
+                        r.Equals(localKey) ? 0 :
+                        (EnumSets.eSharedGovernorRoles.Contains(r) ? 1 : 2)
+                    ).ToList();
+
+                    var representative = orderedFamily.FirstOrDefault(r => dto.RoleDisplayPolicies.ContainsKey(r));
+                    return representative.Equals(default(eLookupGovernorRole)) ? localKey : representative;
+                })
+                .Distinct()
+                .ToList();
+
             foreach (var role in roles)
             {
                 var equivalentRoles = RoleEquivalence.GetEquivalentToLocalRole(role).Cast<int>().ToList();
@@ -170,7 +193,27 @@ namespace Edubase.Web.UI.Areas.Governors.Models
 
                 var list = governors
                     .Where(x => x.RoleId.HasValue && equivalentRoles.Contains(x.RoleId.Value));
-                foreach (var governor in list)
+
+                // PATCH: De-duplicate rows that represent the same person across local/shared equivalents
+                var deduped = list
+                    .GroupBy(g => new
+                    {
+                        First = (g.Person_FirstName ?? string.Empty).Trim(),
+                        Last = (g.Person_LastName ?? string.Empty).Trim(),
+                        Dob = g.DOB
+                    })
+                    .Select(grp =>
+                        // Prefer LocalGovernor over shared variants; then Group_SharedLocalGovernor; then Establishment_SharedLocalGovernor.
+                        grp.OrderBy(x =>
+                            x.RoleId == (int) GR.LocalGovernor ? 0 :
+                            x.RoleId == (int) GR.Group_SharedLocalGovernor ? 1 :
+                            x.RoleId == (int) GR.Establishment_SharedLocalGovernor ? 2 : 3
+                        ).First()
+                    )
+                    .ToList();
+
+                // Use the deduped list from here on:
+                foreach (var governor in deduped)
                 {
                     var isShared = governor.RoleId.HasValue && EnumSets.SharedGovernorRoles.Contains(governor.RoleId.Value);
                     var establishments = string.Join(
@@ -179,7 +222,6 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     );
 
                     GovernorAppointment appointment;
-
                     try
                     {
                         appointment = governor.Appointments?
@@ -195,6 +237,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                     var startDate = isShared && appointment != null
                         ? appointment.AppointmentStartDate
                         : governor.AppointmentStartDate;
+
                     var endDate = isShared && appointment != null
                         ? appointment.AppointmentEndDate
                         : governor.AppointmentEndDate;
@@ -259,6 +302,7 @@ namespace Edubase.Web.UI.Areas.Governors.Models
                         HistoricGovernors.Add(gov);
                     }
                 }
+
 
                 grid.Rows = grid.Rows
                     .OrderByDescending(x => x.SortValue)

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -45,9 +45,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
         private readonly Mock<IIdentity> mockIdentity = new Mock<IIdentity>(MockBehavior.Strict);
         private readonly Mock<IGovernorsGridViewModelFactory> mockGovernorGridViewModelFactory = new Mock<IGovernorsGridViewModelFactory>(MockBehavior.Strict);
 
-
-
-
         private bool disposedValue;
 
         public GovernorControllerTests()
@@ -1055,7 +1052,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             // Arrange
             var estabId = 123456;
 
-            // Duplicate person across Local + Shared roles
+            // Duplicate person across Group & Establishment Shared roles
             var samePerson_Local = new GovernorModel
             {
                 Id = 2001,
@@ -1084,12 +1081,14 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 ApplicableRoles = new List<eLookupGovernorRole>
                 {
                     eLookupGovernorRole.LocalGovernor,
-                    eLookupGovernorRole.Group_SharedLocalGovernor
+                    eLookupGovernorRole.Group_SharedLocalGovernor,
+                    eLookupGovernorRole.Establishment_SharedLocalGovernor
                 },
                         RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
                 {
                     { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
-                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.Establishment_SharedLocalGovernor, new GovernorDisplayPolicy() }
                 },
                 CurrentGovernors = new List<GovernorModel> { samePerson_Local, samePerson_Shared },
                 HistoricalGovernors = new List<GovernorModel>()
@@ -1174,7 +1173,9 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 .SelectMany(g => g.Rows)
                     .ToList();
 
-            Assert.Single(allRows);
+            Assert.Equal(2, allRows.Count);
+            Assert.Contains(allRows, r => ((GovernorModel) r.Model).RoleId == (int) eLookupGovernorRole.Group_SharedLocalGovernor);
+            Assert.Contains(allRows, r => ((GovernorModel) r.Model).RoleId == (int) eLookupGovernorRole.Establishment_SharedLocalGovernor);
         }
 
         [Fact()]

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -1059,8 +1059,9 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             var samePerson_Local = new GovernorModel
             {
                 Id = 2001,
-                RoleId = (int) eLookupGovernorRole.LocalGovernor,
+                RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor,
                 Person_FirstName = "Alex",
+                Person_MiddleName = "J",
                 Person_LastName = "Taylor",
                 DOB = new DateTime(1980, 1, 1),
                 Person_TitleId = 1
@@ -1069,8 +1070,9 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             var samePerson_Shared = new GovernorModel
             {
                 Id = 2002,
-                RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor,
+                RoleId = (int) eLookupGovernorRole.Establishment_SharedLocalGovernor,
                 Person_FirstName = "Alex",
+                Person_MiddleName = "J",
                 Person_LastName = "Taylor",
                 DOB = new DateTime(1980, 1, 1),
                 Person_TitleId = 1

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -1046,14 +1047,14 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             Assert.Equal((eLookupGovernorRole) governor.RoleId, model.Role);
         }
 
+
         [Fact]
         public async Task Gov_Edit_ShouldNotDuplicateGovernors_WhenLocalAndSharedExistForSamePerson()
         {
             // Arrange
             var estabId = 123456;
 
-            // Duplicate person across Group & Establishment Shared roles
-            var samePerson_Local = new GovernorModel
+            var samePerson_GroupShared = new GovernorModel
             {
                 Id = 2001,
                 RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor,
@@ -1064,7 +1065,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 Person_TitleId = 1
             };
 
-            var samePerson_Shared = new GovernorModel
+            var samePerson_EstabShared = new GovernorModel
             {
                 Id = 2002,
                 RoleId = (int) eLookupGovernorRole.Establishment_SharedLocalGovernor,
@@ -1075,8 +1076,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 Person_TitleId = 1
             };
 
-            // IMPORTANT: ApplicableRoles AND RoleDisplayPolicies must be populated
-            var governorDetailsDto = new GovernorsDetailsDto
+            var dto = new GovernorsDetailsDto
             {
                 ApplicableRoles = new List<eLookupGovernorRole>
                 {
@@ -1084,98 +1084,478 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                     eLookupGovernorRole.Group_SharedLocalGovernor,
                     eLookupGovernorRole.Establishment_SharedLocalGovernor
                 },
-                        RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
                 {
                     { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
                     { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() },
                     { eLookupGovernorRole.Establishment_SharedLocalGovernor, new GovernorDisplayPolicy() }
                 },
-                CurrentGovernors = new List<GovernorModel> { samePerson_Local, samePerson_Shared },
+                CurrentGovernors = new List<GovernorModel> { samePerson_GroupShared, samePerson_EstabShared },
                 HistoricalGovernors = new List<GovernorModel>()
             };
 
-            // 1) List + permissions
-            mockGovernorsReadService
-                .Setup(s => s.GetGovernorListAsync(estabId, null, It.IsAny<IPrincipal>()))
-                .ReturnsAsync(governorDetailsDto);
-
-            mockGovernorsReadService
-                .Setup(s => s.GetGovernorPermissions(estabId, null, It.IsAny<IPrincipal>()))
-                .ReturnsAsync(new GovernorPermissions());
-
-            // 2) Lookups (minimal)
-            mockCachedLookupService
-                .Setup(s => s.NationalitiesGetAllAsync())
-                .ReturnsAsync(new List<LookupDto>());
-
-            mockCachedLookupService
-                .Setup(s => s.GovernorAppointingBodiesGetAllAsync())
-                .ReturnsAsync(new List<LookupDto>());
-
-            mockCachedLookupService
-                .Setup(s => s.TitlesGetAllAsync())
-                .ReturnsAsync(new List<LookupDto> { new LookupDto { Id = 1, Name = "Mr" } });
-
-            mockCachedLookupService
-                .Setup(s => s.GovernorRolesGetAllAsync())
-                .ReturnsAsync(new List<LookupDto>
-                {
-            new LookupDto { Id = (int)eLookupGovernorRole.LocalGovernor, Name = "Local Governor" },
-            new LookupDto { Id = (int)eLookupGovernorRole.Group_SharedLocalGovernor, Name = "Shared Local Governor" }
-                });
-
-            // (Optional) 3) Display policy mocks – not needed by Edit(), but harmless
-            mockGovernorsReadService
-                .Setup(s => s.GetEditorDisplayPolicyAsync(
-                    eLookupGovernorRole.LocalGovernor, It.IsAny<bool>(), It.IsAny<IPrincipal>()))
-                .ReturnsAsync(new GovernorDisplayPolicy());
-
-            mockGovernorsReadService
-                .Setup(s => s.GetEditorDisplayPolicyAsync(
-                    eLookupGovernorRole.Group_SharedLocalGovernor, It.IsAny<bool>(), It.IsAny<IPrincipal>()))
-                .ReturnsAsync(new GovernorDisplayPolicy());
-
-            // 4) Layout helper + HttpContext
-            mockLayoutHelper
-                .Setup(l => l.PopulateLayoutProperties(
-                    It.IsAny<GovernorsGridViewModel>(),
-                    estabId, null, It.IsAny<IPrincipal>(),
-                    It.IsAny<Action<EstablishmentModel>>(),
-                    It.IsAny<Action<GroupModel>>()))
-                .Returns(Task.CompletedTask);
-
-            var httpContext = new Mock<System.Web.HttpContextBase>();
-            var httpRequest = new Mock<System.Web.HttpRequestBase>();
-            httpRequest.Setup(r => r.QueryString)
-                       .Returns(new System.Collections.Specialized.NameValueCollection());
-            httpContext.Setup(c => c.Request).Returns(httpRequest.Object);
-
-            var controller = new GovernorController(
-                mockGovernorsReadService.Object,
-                mockCachedLookupService.Object,
-                mockGovernorsWriteService.Object,
-                mockGroupReadService.Object,
-                mockEstablishmentReadService.Object,
-                mockLayoutHelper.Object
-            );
-
-            controller.ControllerContext = new ControllerContext(
-                new System.Web.Routing.RequestContext(httpContext.Object, new System.Web.Routing.RouteData()),
-                controller);
+            WireEdit(estabId, dto);
+            var controller = BuildController();
 
             // Act
             var actionResult = await controller.Edit(null, estabId, null, null);
             var viewResult = Assert.IsType<ViewResult>(actionResult);
             var model = Assert.IsType<GovernorsGridViewModel>(viewResult.Model);
 
-            // Assert
-            var allRows = model.Grids
-                .SelectMany(g => g.Rows)
-                    .ToList();
-
+            // Assert 
+            var allRows = model.Grids.SelectMany(g => g.Rows).ToList();
             Assert.Equal(2, allRows.Count);
             Assert.Contains(allRows, r => ((GovernorModel) r.Model).RoleId == (int) eLookupGovernorRole.Group_SharedLocalGovernor);
             Assert.Contains(allRows, r => ((GovernorModel) r.Model).RoleId == (int) eLookupGovernorRole.Establishment_SharedLocalGovernor);
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldCreateOneGridPerRoleId()
+        {
+            var estabId = 1001;
+
+            var gLocal = new GovernorModel { Id = 1, RoleId = (int) eLookupGovernorRole.LocalGovernor, Person_FirstName = "A" };
+            var gShared = new GovernorModel { Id = 2, RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor, Person_FirstName = "B" };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>
+                {
+                    eLookupGovernorRole.LocalGovernor, eLookupGovernorRole.Group_SharedLocalGovernor
+                },
+                CurrentGovernors = new List<GovernorModel> { gLocal, gShared },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            var result = await controller.Edit(null, estabId, null, null);
+            var vm = Assert.IsType<GovernorsGridViewModel>(Assert.IsType<ViewResult>(result).Model);
+
+            Assert.Equal(2, vm.Grids.Count);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor).Rows);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.Group_SharedLocalGovernor).Rows);
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldNotBleedRowsAcrossGrids()
+        {
+            var estabId = 1002;
+
+            var gShared = new GovernorModel
+            {
+                Id = 10,
+                RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor,
+                Person_FirstName = "Alex"
+            };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>
+                {
+                    eLookupGovernorRole.LocalGovernor, eLookupGovernorRole.Group_SharedLocalGovernor
+                },
+                CurrentGovernors = new List<GovernorModel> { gShared },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            var result = await controller.Edit(null, estabId, null, null);
+            var vm = Assert.IsType<GovernorsGridViewModel>(Assert.IsType<ViewResult>(result).Model);
+
+            Assert.Equal(2, vm.Grids.Count);
+            Assert.Empty(vm.Grids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor).Rows);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.Group_SharedLocalGovernor).Rows);
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldRenderHistoricGrids_OnePerRole()
+        {
+            var estabId = 1003;
+
+            var h1 = new GovernorModel { Id = 100, RoleId = (int) eLookupGovernorRole.Governor, Person_FirstName = "H1" };
+            var h2 = new GovernorModel { Id = 101, RoleId = (int) eLookupGovernorRole.LocalGovernor, Person_FirstName = "H2" };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.Governor, eLookupGovernorRole.LocalGovernor },
+                CurrentGovernors = new List<GovernorModel>(),
+                HistoricalGovernors = new List<GovernorModel> { h1, h2 },
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.Governor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            var result = await controller.Edit(null, estabId, null, null);
+            var vm = Assert.IsType<GovernorsGridViewModel>(Assert.IsType<ViewResult>(result).Model);
+
+            Assert.Equal(2, vm.HistoricGrids.Count);
+            Assert.Single(vm.HistoricGrids.Single(g => g.Role == eLookupGovernorRole.Governor).Rows);
+            Assert.Single(vm.HistoricGrids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor).Rows);
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldThrow_WhenDisplayPolicyMissingForRole()
+        {
+            var estabId = 1004;
+
+            var g = new GovernorModel
+            {
+                Id = 7,
+                RoleId = (int) eLookupGovernorRole.Establishment_SharedLocalGovernor,
+                Person_FirstName = "P"
+            };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.Establishment_SharedLocalGovernor },
+                CurrentGovernors = new List<GovernorModel> { g },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>() // Missing policy
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            await Assert.ThrowsAsync<Exception>(async () => await controller.Edit(null, estabId, null, null));
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldRender_WhenAllDisplayPoliciesPresent()
+        {
+            var estabId = 1005;
+
+            var g = new GovernorModel
+            {
+                Id = 8,
+                RoleId = (int) eLookupGovernorRole.Establishment_SharedLocalGovernor,
+                Person_FirstName = "P"
+            };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.Establishment_SharedLocalGovernor },
+                CurrentGovernors = new List<GovernorModel> { g },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.Establishment_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            var result = await controller.Edit(null, estabId, null, null);
+            var vm = Assert.IsType<GovernorsGridViewModel>(Assert.IsType<ViewResult>(result).Model);
+
+            Assert.Single(vm.Grids);
+            Assert.Single(vm.Grids[0].Rows);
+        }
+
+        [Fact]
+        public async Task Gov_Edit_ShouldPopulateLayoutProperties()
+        {
+            var estabId = 1006;
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>(),
+                CurrentGovernors = new List<GovernorModel>(),
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>()
+            };
+
+            WireEdit(estabId, dto);
+            var controller = BuildController();
+
+            var result = await controller.Edit(null, estabId, null, null);
+            Assert.IsType<ViewResult>(result);
+
+            mockLayoutHelper.Verify(l => l.PopulateLayoutProperties(
+                It.IsAny<GovernorsGridViewModel>(),
+                estabId,
+                null,
+                It.IsAny<IPrincipal>(),
+                It.IsAny<Action<Edubase.Services.Establishments.Models.EstablishmentModel>>(),
+                It.IsAny<Action<Edubase.Services.Groups.Models.GroupModel>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Gov_ReplaceChair_Get_ShouldRender_WithPolicies()
+        {
+            // Arrange
+            var estabId = 2001;
+            var gid = 3001;
+
+            var chair = new GovernorModel
+            {
+                Id = gid,
+                RoleId = (int) eLookupGovernorRole.ChairOfLocalGoverningBody
+            };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.Governor },
+                CurrentGovernors = new List<GovernorModel>(),      
+                HistoricalGovernors = new List<GovernorModel>(),    
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.Governor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorAsync(gid, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(chair);
+
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorListAsync(estabId, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(dto);
+
+            mockGovernorsReadService
+                .Setup(s => s.GetSharedGovernorsAsync(estabId, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new List<GovernorModel>()); 
+
+            mockGovernorsReadService
+                .Setup(s => s.GetEditorDisplayPolicyAsync(
+                    It.IsAny<eLookupGovernorRole>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorDisplayPolicy());
+
+            mockCachedLookupService.Setup(s => s.NationalitiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.GovernorAppointingBodiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.TitlesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+
+            mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(
+                It.IsAny<ReplaceChairViewModel>(),
+                estabId,
+                null,
+                It.IsAny<IPrincipal>(),
+                It.IsAny<Action<Edubase.Services.Establishments.Models.EstablishmentModel>>(),
+                It.IsAny<Action<Edubase.Services.Groups.Models.GroupModel>>()))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController();
+
+            // Act
+            var result = await controller.ReplaceChair(estabId, gid);
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var vm = Assert.IsType<ReplaceChairViewModel>(viewResult.Model);
+
+            // Assert
+            Assert.Equal(gid, vm.ExistingGovernorId);
+            Assert.Equal((eLookupGovernorRole) chair.RoleId, vm.Role);
+        }
+
+        [Fact]
+        public async Task Gov_ReplaceChair_Post_Shared_AddsAppointment_AndClosesOld()
+        {
+            var estabUrn = 2002;
+            var newGovId = 4002;
+            var oldGovId = 4001;
+
+            mockGovernorsWriteService.Setup(s =>
+                s.AddSharedGovernorAppointmentAsync(newGovId, estabUrn,
+                    It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new ApiResponse(true));
+
+            mockGovernorsReadService.Setup(s =>
+                s.GetGovernorAsync(newGovId, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorModel
+                {
+                    Id = newGovId,
+                    RoleId = (int) eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody,
+                    AppointmentEndDate = DateTime.Today.AddYears(1),
+                    AppointmentStartDate = DateTime.Today.AddYears(-2),
+                    Appointments = new[]
+                    {
+                new GovernorAppointment
+                {
+                    EstablishmentUrn = estabUrn,
+                    AppointmentStartDate = DateTime.Today.AddYears(-2),
+                    AppointmentEndDate = DateTime.Today.AddYears(1)
+                }
+                    }
+                });
+
+            mockGovernorsReadService.Setup(s =>
+                s.GetGovernorAsync(oldGovId, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorModel
+                {
+                    Id = oldGovId,
+                    RoleId = (int) eLookupGovernorRole.ChairOfLocalGoverningBody,
+                    AppointmentEndDate = DateTime.Today
+                });
+
+            mockGovernorsWriteService.Setup(s =>
+                s.UpdateDatesAsync(oldGovId, It.IsAny<DateTime>(), It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new ApiResponse(true));
+
+            // REQUIRED mocks for ReplaceChair POST
+            mockGovernorsReadService.Setup(s =>
+                s.GetSharedGovernorsAsync(estabUrn, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new List<GovernorModel>());
+
+            mockGovernorsReadService.Setup(s =>
+                s.GetEditorDisplayPolicyAsync(It.IsAny<eLookupGovernorRole>(),
+                    It.IsAny<bool>(), It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorDisplayPolicy());
+
+            mockGovernorsReadService.Setup(s =>
+                s.GetGovernorListAsync(estabUrn, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorsDetailsDto
+                {
+                    ApplicableRoles = new List<eLookupGovernorRole>
+                    {
+                eLookupGovernorRole.ChairOfLocalGoverningBody,
+                eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody
+                    },
+                    CurrentGovernors = new List<GovernorModel>(),
+                    HistoricalGovernors = new List<GovernorModel>(),
+                    RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                    {
+                { eLookupGovernorRole.ChairOfLocalGoverningBody, new GovernorDisplayPolicy() },
+                { eLookupGovernorRole.Establishment_SharedChairOfLocalGoverningBody, new GovernorDisplayPolicy() }
+                    }
+                });
+
+            mockCachedLookupService.Setup(s => s.NationalitiesGetAllAsync()).ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.GovernorAppointingBodiesGetAllAsync()).ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.TitlesGetAllAsync()).ReturnsAsync(new List<LookupDto>());
+
+            var controller = BuildController(); // uses FakeUrlHelper or stub URL
+
+            var model = new ReplaceChairViewModel
+            {
+                ExistingGovernorId = oldGovId,
+                Urn = estabUrn,
+                NewChairType = ReplaceChairViewModel.ChairType.SharedChair,
+                SharedGovernors = new List<SharedGovernorViewModel>
+                {
+                    new SharedGovernorViewModel
+                    {
+                        Id = newGovId,
+                        AppointmentEndDate = new DateTimeViewModel(DateTime.Today.AddYears(1))
+                    }
+                },
+                DateTermEnds = new DateTimeViewModel(DateTime.Today)
+            };
+
+            model.SelectedGovernorId = newGovId;
+
+            // Act
+            var result = await controller.ReplaceChair(model);
+
+            // Assert
+            var redirect = Assert.IsType<RedirectResult>(result);
+            Assert.Contains("#school-governance", redirect.Url);
+
+            mockGovernorsWriteService.Verify(s =>
+                s.AddSharedGovernorAppointmentAsync(newGovId, estabUrn,
+                    It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IPrincipal>()),
+                Times.Once);
+
+            mockGovernorsWriteService.Verify(s =>
+                s.UpdateDatesAsync(oldGovId, It.IsAny<DateTime>(), It.IsAny<IPrincipal>()),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null, 999)]   // group context
+        [InlineData(888, null)]   // establishment context
+        public async Task Gov_DeleteOrRetireGovernor_Save_Success(int? estabId, int? groupId)
+        {
+            // Arrange
+            var governorId = 123;
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.Governor },
+                CurrentGovernors = new List<GovernorModel>
+        {
+            new GovernorModel
+            {
+                Id = governorId,
+                RoleId = (int)eLookupGovernorRole.Governor,
+                Person_FirstName = "Test",
+                Person_TitleId = 1,
+                Appointments = new[]
+                {
+                    new GovernorAppointment
+                    {
+                        EstablishmentUrn = estabId ?? 12345,
+                        AppointmentStartDate = DateTime.Today.AddYears(-1),
+                        AppointmentEndDate = null
+                    }
+                }
+            }
+        },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+        {
+            { eLookupGovernorRole.Governor, new GovernorDisplayPolicy() }
+        }
+            };
+
+            // mock list + permission
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorListAsync(estabId, groupId, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(dto);
+
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorPermissions(estabId, groupId, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorPermissions());
+
+            // delete call
+            mockGovernorsWriteService
+                .Setup(s => s.DeleteAsync(governorId, It.IsAny<IPrincipal>()))
+                .Returns(Task.FromResult(new ApiResponse(true)));
+
+            var controller = BuildController();
+
+            // IMPORTANT: we must set GovernorShared = false and use Action="Remove"
+            var postedModel = new GovernorsGridViewModel
+            {
+                EstablishmentUrn = estabId,
+                GroupUId = groupId,
+                Action = "Remove",
+                GovernorShared = false,
+                RemovalGid = governorId,
+                RemovalAppointmentEndDate = new DateTimeViewModel(DateTime.Today)
+            };
+
+            // Act
+            var result = await controller.DeleteOrRetireGovernor(postedModel);
+
+            // Assert
+            var redirect = Assert.IsType<RedirectResult>(result);
+
+            mockGovernorsWriteService.Verify(
+                s => s.DeleteAsync(governorId, It.IsAny<IPrincipal>()),
+                Times.Once);
         }
 
         [Fact()]
@@ -1508,6 +1888,111 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             var actualResult = await controller.RoleAllowed(newGovernorRole, null, null, null, false);
 
             Assert.Equal(expectedResult, actualResult);
+        }
+
+        private GovernorController BuildController()
+        {
+            var controller = new GovernorController(
+                mockGovernorsReadService.Object,
+                mockCachedLookupService.Object,
+                mockGovernorsWriteService.Object,
+                mockGroupReadService.Object,
+                mockEstablishmentReadService.Object,
+                mockLayoutHelper.Object);
+
+            // -----------------------------
+            // HttpContext + HttpRequest
+            // -----------------------------
+            var httpContext = new Mock<HttpContextBase>();
+            var httpRequest = new Mock<HttpRequestBase>();
+
+            httpRequest.Setup(r => r.QueryString)
+                .Returns(new NameValueCollection());
+
+            // ⭐ REQUIRED FOR MVC URL GENERATION
+            httpRequest.Setup(r => r.ApplicationPath).Returns("/");
+            httpRequest.Setup(r => r.AppRelativeCurrentExecutionFilePath).Returns("~/");
+            httpRequest.Setup(r => r.Path).Returns("/");
+            httpRequest.Setup(r => r.RawUrl).Returns("/");
+            httpRequest.Setup(r => r.PhysicalApplicationPath).Returns("C:\\FakeApp\\");
+
+            httpContext.Setup(c => c.Request).Returns(httpRequest.Object);
+
+            var routeData = new RouteData();
+            var requestContext = new RequestContext(httpContext.Object, routeData);
+
+            controller.ControllerContext = new ControllerContext(requestContext, controller);
+
+            RouteTable.Routes.Clear();
+
+            RouteTable.Routes.MapRoute(
+                name: "EstabDetails",
+                url: "establishment/{id}",
+                defaults: new { controller = "Establishment", action = "Details" }
+            );
+
+            RouteTable.Routes.MapRoute(
+                name: "GroupDetails",
+                url: "group/{id}",
+                defaults: new { controller = "Group", action = "Details" }
+            );
+
+            controller.Url = new FakeUrlHelper();
+
+            return controller;
+        }
+
+        private void WireEdit(int estabId, GovernorsDetailsDto dto)
+        {
+            // Data + permissions
+            mockGovernorsReadService.Setup(s => s.GetGovernorListAsync(estabId, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(dto);
+            mockGovernorsReadService.Setup(s => s.GetGovernorPermissions(estabId, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorPermissions());
+
+            // Lookups used by Edit()
+            mockCachedLookupService.Setup(s => s.GovernorRolesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.TitlesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.NationalitiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+            mockCachedLookupService.Setup(s => s.GovernorAppointingBodiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+
+            // Layout
+            mockLayoutHelper.Setup(l => l.PopulateLayoutProperties(
+                It.IsAny<GovernorsGridViewModel>(),
+                estabId,
+                null,
+                It.IsAny<IPrincipal>(),
+                It.IsAny<Action<Edubase.Services.Establishments.Models.EstablishmentModel>>(),
+                It.IsAny<Action<Edubase.Services.Groups.Models.GroupModel>>()))
+                .Returns(Task.CompletedTask);
+        }
+
+        internal sealed class FakeUrlHelper : UrlHelper
+        {
+            public FakeUrlHelper() : base(new RequestContext(new FakeHttpContext(), new RouteData())) { }
+
+            public override string RouteUrl(string routeName, object routeValues)
+            {
+                return "/fake-url";
+            }
+        }
+
+        internal sealed class FakeHttpContext : HttpContextBase
+        {
+            private readonly HttpRequestBase _request = new FakeHttpRequest();
+            public override HttpRequestBase Request => _request;
+        }
+
+        internal sealed class FakeHttpRequest : HttpRequestBase
+        {
+            public override string ApplicationPath => "/";
+            public override string AppRelativeCurrentExecutionFilePath => "~/";
+            public override string Path => "/";
+            public override string RawUrl => "/";
         }
     }
 }

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -1520,7 +1520,6 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
         }
             };
 
-            // mock list + permission
             mockGovernorsReadService
                 .Setup(s => s.GetGovernorListAsync(estabId, groupId, It.IsAny<IPrincipal>()))
                 .ReturnsAsync(dto);
@@ -1529,14 +1528,12 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 .Setup(s => s.GetGovernorPermissions(estabId, groupId, It.IsAny<IPrincipal>()))
                 .ReturnsAsync(new GovernorPermissions());
 
-            // delete call
             mockGovernorsWriteService
                 .Setup(s => s.DeleteAsync(governorId, It.IsAny<IPrincipal>()))
                 .Returns(Task.FromResult(new ApiResponse(true)));
 
             var controller = BuildController();
 
-            // IMPORTANT: we must set GovernorShared = false and use Action="Remove"
             var postedModel = new GovernorsGridViewModel
             {
                 EstablishmentUrn = estabId,
@@ -1900,16 +1897,14 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 mockEstablishmentReadService.Object,
                 mockLayoutHelper.Object);
 
-            // -----------------------------
             // HttpContext + HttpRequest
-            // -----------------------------
             var httpContext = new Mock<HttpContextBase>();
             var httpRequest = new Mock<HttpRequestBase>();
 
             httpRequest.Setup(r => r.QueryString)
                 .Returns(new NameValueCollection());
 
-            // ⭐ REQUIRED FOR MVC URL GENERATION
+            // Required for MVC URL generation
             httpRequest.Setup(r => r.ApplicationPath).Returns("/");
             httpRequest.Setup(r => r.AppRelativeCurrentExecutionFilePath).Returns("~/");
             httpRequest.Setup(r => r.Path).Returns("/");

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -1172,7 +1172,7 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
                 .SelectMany(g => g.Rows)
                     .ToList();
 
-            Assert.Equal(1, allRows.Count);
+            Assert.Single(allRows);
         }
 
         [Fact()]

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Controllers/GovernorControllerTests.cs
@@ -1049,6 +1049,132 @@ namespace Edubase.Web.UI.Areas.Governors.Controllers.UnitTests
             Assert.Equal((eLookupGovernorRole) governor.RoleId, model.Role);
         }
 
+        [Fact]
+        public async Task Gov_Edit_ShouldNotDuplicateGovernors_WhenLocalAndSharedExistForSamePerson()
+        {
+            // Arrange
+            var estabId = 123456;
+
+            // Duplicate person across Local + Shared roles
+            var samePerson_Local = new GovernorModel
+            {
+                Id = 2001,
+                RoleId = (int) eLookupGovernorRole.LocalGovernor,
+                Person_FirstName = "Alex",
+                Person_LastName = "Taylor",
+                DOB = new DateTime(1980, 1, 1),
+                Person_TitleId = 1
+            };
+
+            var samePerson_Shared = new GovernorModel
+            {
+                Id = 2002,
+                RoleId = (int) eLookupGovernorRole.Group_SharedLocalGovernor,
+                Person_FirstName = "Alex",
+                Person_LastName = "Taylor",
+                DOB = new DateTime(1980, 1, 1),
+                Person_TitleId = 1
+            };
+
+            // IMPORTANT: ApplicableRoles AND RoleDisplayPolicies must be populated
+            var governorDetailsDto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>
+                {
+                    eLookupGovernorRole.LocalGovernor,
+                    eLookupGovernorRole.Group_SharedLocalGovernor
+                },
+                        RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                },
+                CurrentGovernors = new List<GovernorModel> { samePerson_Local, samePerson_Shared },
+                HistoricalGovernors = new List<GovernorModel>()
+            };
+
+            // 1) List + permissions
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorListAsync(estabId, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(governorDetailsDto);
+
+            mockGovernorsReadService
+                .Setup(s => s.GetGovernorPermissions(estabId, null, It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorPermissions());
+
+            // 2) Lookups (minimal)
+            mockCachedLookupService
+                .Setup(s => s.NationalitiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+
+            mockCachedLookupService
+                .Setup(s => s.GovernorAppointingBodiesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>());
+
+            mockCachedLookupService
+                .Setup(s => s.TitlesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto> { new LookupDto { Id = 1, Name = "Mr" } });
+
+            mockCachedLookupService
+                .Setup(s => s.GovernorRolesGetAllAsync())
+                .ReturnsAsync(new List<LookupDto>
+                {
+            new LookupDto { Id = (int)eLookupGovernorRole.LocalGovernor, Name = "Local Governor" },
+            new LookupDto { Id = (int)eLookupGovernorRole.Group_SharedLocalGovernor, Name = "Shared Local Governor" }
+                });
+
+            // (Optional) 3) Display policy mocks – not needed by Edit(), but harmless
+            mockGovernorsReadService
+                .Setup(s => s.GetEditorDisplayPolicyAsync(
+                    eLookupGovernorRole.LocalGovernor, It.IsAny<bool>(), It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorDisplayPolicy());
+
+            mockGovernorsReadService
+                .Setup(s => s.GetEditorDisplayPolicyAsync(
+                    eLookupGovernorRole.Group_SharedLocalGovernor, It.IsAny<bool>(), It.IsAny<IPrincipal>()))
+                .ReturnsAsync(new GovernorDisplayPolicy());
+
+            // 4) Layout helper + HttpContext
+            mockLayoutHelper
+                .Setup(l => l.PopulateLayoutProperties(
+                    It.IsAny<GovernorsGridViewModel>(),
+                    estabId, null, It.IsAny<IPrincipal>(),
+                    It.IsAny<Action<EstablishmentModel>>(),
+                    It.IsAny<Action<GroupModel>>()))
+                .Returns(Task.CompletedTask);
+
+            var httpContext = new Mock<System.Web.HttpContextBase>();
+            var httpRequest = new Mock<System.Web.HttpRequestBase>();
+            httpRequest.Setup(r => r.QueryString)
+                       .Returns(new System.Collections.Specialized.NameValueCollection());
+            httpContext.Setup(c => c.Request).Returns(httpRequest.Object);
+
+            var controller = new GovernorController(
+                mockGovernorsReadService.Object,
+                mockCachedLookupService.Object,
+                mockGovernorsWriteService.Object,
+                mockGroupReadService.Object,
+                mockEstablishmentReadService.Object,
+                mockLayoutHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext(
+                new System.Web.Routing.RequestContext(httpContext.Object, new System.Web.Routing.RouteData()),
+                controller);
+
+            // Act
+            var actionResult = await controller.Edit(null, estabId, null, null);
+            var viewResult = Assert.IsType<ViewResult>(actionResult);
+            var model = Assert.IsType<GovernorsGridViewModel>(viewResult.Model);
+
+            // Assert
+            var allRows = model.Grids
+                .SelectMany(g => g.Rows)
+                    .ToList();
+
+            Assert.Equal(1, allRows.Count);
+        }
+
         [Fact()]
         public async Task Gov_Put_ReplaceChair_NewChairShared()
         {

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
@@ -12,7 +12,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
 {
     public class GovernorsGridViewModelTests
     {
-        // 1. SAME person, DIFFERENT roles => SEPARATE grids, SEPARATE rows
         [Fact]
         public void CreateGrids_ShouldNotMergeDifferentRoles_ForSamePerson()
         {
@@ -28,7 +27,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
-        // 2. SAME role, TWO appointments => TWO rows (no row dedupe)
         [Fact]
         public void CreateGrids_ShouldListAllAppointments_ForSameRole()
         {
@@ -43,7 +41,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
-        // 3. Distinct roles => distinct grids
         [Fact]
         public void CreateGrids_ShouldCreateSeparateGrids_ForDistinctRoles()
         {
@@ -57,7 +54,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
-        // 4. Exact-role-matching: NO bleed across into unrelated grids
         [Fact]
         public void CreateGrids_ShouldUseExactRoleMatching_NoBleedAcrossGrids()
         {
@@ -89,7 +85,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Single(sharedGrid.Rows);
         }
 
-        // 5. Historic grids behave the same as current grids
         [Fact]
         public void CreateGrids_Historic_ShouldListAllAppointments()
         {
@@ -104,7 +99,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(2, vm.HistoricGrids.SelectMany(g => g.Rows).Count());
         }
 
-        // 6. Every roleId must have a DisplayPolicy
         [Fact]
         public void CreateGrids_ShouldThrow_WhenDisplayPolicyMissing()
         {
@@ -120,7 +114,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Throws<Exception>(() => Build(dto));
         }
 
-        // 7. With display policy present → should NOT throw
         [Fact]
         public void CreateGrids_ShouldNotThrow_WhenDisplayPolicyPresent()
         {
@@ -133,7 +126,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Single(vm.Grids);
         }
 
-        // 8. Sorting by name
         [Fact]
         public void CreateGrids_ShouldSortRowsByName_WhenSortValueNull()
         {
@@ -149,7 +141,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(new[] { "Adam Baker", "Ben Alpha", "Charlie Zed" }, rows);
         }
 
-        // 9. Multi-appointments for same roleId + same URN throws
         [Fact]
         public void CreateGrids_ShouldThrow_WhenMultipleAppointmentsForSameUrn()
         {
@@ -166,7 +157,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Throws<InvalidOperationException>(() => Build(dto));
         }
 
-        // 10. Correct appointment chosen for shared roles
         [Fact]
         public void CreateGrids_ShouldSelectCorrectAppointment_ForSharedRoles()
         {
@@ -207,7 +197,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Contains("1 January 2021", cellTexts);
         }
 
-        // 11. Governance Professional roles produce separate grids
         [Fact]
         public void CreateGrids_ShouldCreateSeparateGrids_ForGovernanceProfessionalRoles()
         {
@@ -220,7 +209,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Equal(2, vm.Grids.Count);
         }
 
-        // 12. Governance Professional shared “Shared with” column only for shared GP roles
         [Fact]
         public void CreateGrids_ShouldIncludeSharedWithColumn_ForSharedGP()
         {
@@ -234,7 +222,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.Contains("Shared with", headers);
         }
 
-        // 13. Non-shared GP roles should NOT show “Shared with”
         [Fact]
         public void CreateGrids_ShouldNotIncludeSharedWithColumn_ForNonSharedGP()
         {
@@ -248,7 +235,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             Assert.DoesNotContain("Shared with", headers);
         }
 
-        // 14. Multi-role scenario: no bleed, exactly one grid per roleId
         [Fact]
         public void CreateGrids_ShouldCreateOneGridPerRole_NoBleed()
         {

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
@@ -25,6 +25,20 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             };
         }
 
+        private GovernorsDetailsDto BuildDtoWith(params GovernorModel[] govs)
+        {
+            return new GovernorsDetailsDto
+            {
+                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
+                CurrentGovernors = govs.ToList(),
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = govs
+                    .Select(g => (eLookupGovernorRole) g.RoleId)
+                    .Distinct()
+                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
+            };
+        }
+
         private GovernorsDetailsDto DtoWith(params GovernorModel[] govs)
         {
             return new GovernorsDetailsDto
@@ -39,6 +53,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             };
         }
 
+        // Create a GovernorDetailsDto with historical governors only.
         private GovernorsDetailsDto DtoHistoric(params GovernorModel[] govs)
         {
             return new GovernorsDetailsDto
@@ -53,6 +68,7 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             };
         }
 
+        // Build a fully constructed GovernorGridViewModel with the minimum required inputs.
         private GovernorsGridViewModel Build(GovernorsDetailsDto dto)
         {
             return new GovernorsGridViewModel(
@@ -137,5 +153,129 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
             // Assert
             Assert.Single(rows);
         }
+
+        [Fact]
+        public void CreateGrids_ShouldNotDeduplicate_WhenTwoDifferentPeopleShareSameNameAndDob_DifferentMiddleName()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+
+            var p1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            p1.Person_MiddleName = "James";
+            p1.PostCode = "AB1 2CD";
+
+            var p2 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            p1.Person_MiddleName = "Marie";
+            p2.PostCode = "XY9 9ZZ";    // Different person
+
+            var dto = BuildDtoWith(p1, p2);
+
+            // Act
+            var vm = Build(dto);
+            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
+
+            // Assert
+            Assert.Equal(2, rows.Count);
+        }
+
+
+        [Fact]
+        public void LocalGovernorFamily_ShouldCollapseToSingleGrid_AndSingleRow()
+        {
+            var dob = new DateTime(1982, 3, 3);
+
+            var local = Gov("Jamie", "Lee", eLookupGovernorRole.LocalGovernor, dob);
+            var shared = Gov("Jamie", "Lee", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+
+            var dto = BuildDtoWith(local, shared);
+            var vm = Build(dto);
+
+            Assert.Single(vm.Grids); // role-level dedupe
+            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
+        }
+
+        [Fact]
+        public void ChairFamily_ShouldPickSharedRole_WhenLocalHasNoPolicy()
+        {
+            var dob = new DateTime(1979, 4, 4);
+
+            var chairLocal = Gov("Ava", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, dob);
+            var chairShared = Gov("Ava", "Singh", eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, dob);
+
+            var dto = BuildDtoWith(chairLocal, chairShared);
+
+            // Only shared has policy
+            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+            {
+                { eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, new GovernorDisplayPolicy() }
+            };
+
+            var vm = Build(dto);
+
+            Assert.Single(vm.Grids);
+            Assert.Equal(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, vm.Grids[0].Role);
+            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
+        }
+
+        [Fact]
+        public void GovernanceProfessionalFamily_ShouldCollapseToSingleGrid_AndSingleRow()
+        {
+            var dob = new DateTime(1990, 6, 6);
+
+            var gpLocal = Gov("Sam", "Morgan", eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, dob);
+            var gpShared = Gov("Sam", "Morgan", eLookupGovernorRole.Group_SharedGovernanceProfessional, dob);
+
+            var dto = BuildDtoWith(gpLocal, gpShared);
+
+            // Only shared has guaranteed policy
+            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+            {
+                { eLookupGovernorRole.Group_SharedGovernanceProfessional, new GovernorDisplayPolicy() }
+            };
+
+            var vm = Build(dto);
+
+            Assert.Single(vm.Grids);  // role family merges
+            Assert.Equal(eLookupGovernorRole.Group_SharedGovernanceProfessional, vm.Grids[0].Role);
+            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
+        }
+
+        [Fact]
+        public void MultipleFamilies_ShouldRenderOneGridPerFamily_AndSingleRowPerFamily()
+        {
+            var dob1 = new DateTime(1985, 2, 2);
+            var dob2 = new DateTime(1975, 3, 3);
+            var dob3 = new DateTime(1991, 7, 7);
+
+            // Family 1: Local Gov
+            var gLocal = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob1);
+            var gShared = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob1);
+
+            // Family 2: Chairs
+            var cLocal = Gov("Ava", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, dob2);
+            var cShared = Gov("Ava", "Singh", eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, dob2);
+
+            // Family 3: Governance Professional
+            var gpLocal = Gov("Sam", "Morgan", eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, dob3);
+            var gpShare = Gov("Sam", "Morgan", eLookupGovernorRole.Group_SharedGovernanceProfessional, dob3);
+
+            var dto = BuildDtoWith(gLocal, gShared, cLocal, cShared, gpLocal, gpShare);
+
+            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+            {
+                { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
+                { eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, new GovernorDisplayPolicy() },
+                { eLookupGovernorRole.Group_SharedGovernanceProfessional, new GovernorDisplayPolicy() }
+            };
+
+            var vm = Build(dto);
+
+            // Expect one grid per family → 3 families
+            Assert.Equal(3, vm.Grids.Count);
+
+            // Expect one deduped row per family → 3 rows
+            Assert.Equal(3, vm.Grids.SelectMany(g => g.Rows).Count());
+        }
+
     }
 }

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
@@ -12,69 +12,58 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
 {
     public class GovernorsGridViewModelTests
     {
+        // 1. SAME person, DIFFERENT roles => SEPARATE grids, SEPARATE rows
         [Fact]
         public void CreateGrids_ShouldNotMergeDifferentRoles_ForSamePerson()
         {
-            // Arrange
             var dob = new DateTime(1980, 1, 1);
+
             var g1 = Gov("Alex", "J", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
             var g2 = Gov("Alex", "J", "Taylor", eLookupGovernorRole.Establishment_SharedLocalGovernor, dob);
 
             var dto = BuildDto(g1, g2);
-
-            // Act
             var vm = Build(dto);
 
-            // Assert
             Assert.Equal(2, vm.Grids.Count);
-            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
-            Assert.Equal(2, rows.Count);   
+            Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
+        // 2. SAME role, TWO appointments => TWO rows (no row dedupe)
         [Fact]
-        public void CreateGrids_ShouldListAllAppointments_WithinSameRole()
+        public void CreateGrids_ShouldListAllAppointments_ForSameRole()
         {
-            // Arrange
             var dob = new DateTime(1990, 1, 1);
             var a1 = Gov("Sam", "", "Morgan", eLookupGovernorRole.LocalGovernor, dob);
             var a2 = Gov("Sam", "", "Morgan", eLookupGovernorRole.LocalGovernor, dob);
 
             var dto = BuildDto(a1, a2);
-
-            // Act
             var vm = Build(dto);
 
-            // Assert
             Assert.Single(vm.Grids);
-            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
-            Assert.Equal(2, rows.Count);
+            Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
+        // 3. Distinct roles => distinct grids
         [Fact]
         public void CreateGrids_ShouldCreateSeparateGrids_ForDistinctRoles()
         {
-            // Arrange
             var g1 = Gov("Ava", "", "Singh", eLookupGovernorRole.LocalGovernor, null);
             var g2 = Gov("Ava", "", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, null);
 
             var dto = BuildDto(g1, g2);
-
-            // Act
             var vm = Build(dto);
 
-            // Assert
             Assert.Equal(2, vm.Grids.Count);
             Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
         }
 
+        // 4. Exact-role-matching: NO bleed across into unrelated grids
         [Fact]
         public void CreateGrids_ShouldUseExactRoleMatching_NoBleedAcrossGrids()
         {
-            // Arrange
             var dob = new DateTime(1985, 5, 5);
             var shared = Gov("Jamie", "", "Lee", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
 
-            // Intentionally include LocalGovernor in ApplicableRoles to ensure a Local grid is created too.
             var dto = new GovernorsDetailsDto
             {
                 ApplicableRoles = new List<eLookupGovernorRole>
@@ -91,35 +80,189 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 }
             };
 
-            // Act
             var vm = Build(dto);
 
-            // Assert
-            Assert.Equal(2, vm.Grids.Count); // Local + Group_Shared grids
             var localGrid = vm.Grids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor);
-            var groupGrid = vm.Grids.Single(g => g.Role == eLookupGovernorRole.Group_SharedLocalGovernor);
+            var sharedGrid = vm.Grids.Single(g => g.Role == eLookupGovernorRole.Group_SharedLocalGovernor);
 
-            Assert.Empty(localGrid.Rows); // exact role matching → no bleed
-            Assert.Single(groupGrid.Rows);
+            Assert.Empty(localGrid.Rows);
+            Assert.Single(sharedGrid.Rows);
         }
 
+        // 5. Historic grids behave the same as current grids
         [Fact]
         public void CreateGrids_Historic_ShouldListAllAppointments()
         {
-            // Arrange
             var dob = new DateTime(1975, 1, 1);
             var g1 = Gov("Chris", "", "Walker", eLookupGovernorRole.Governor, dob);
             var g2 = Gov("Chris", "", "Walker", eLookupGovernorRole.Governor, dob);
 
             var dto = BuildHistoric(g1, g2);
-
-            // Act
             var vm = Build(dto);
 
-            // Assert
             Assert.Single(vm.HistoricGrids);
-            var rows = vm.HistoricGrids.SelectMany(g => g.Rows).ToList();
-            Assert.Equal(2, rows.Count); // NO row dedupe → two historic rows
+            Assert.Equal(2, vm.HistoricGrids.SelectMany(g => g.Rows).Count());
+        }
+
+        // 6. Every roleId must have a DisplayPolicy
+        [Fact]
+        public void CreateGrids_ShouldThrow_WhenDisplayPolicyMissing()
+        {
+            var g = Gov("Alex", "", "Test", eLookupGovernorRole.LocalGovernor, null);
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole> { eLookupGovernorRole.LocalGovernor },
+                CurrentGovernors = new List<GovernorModel> { g },
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>() // missing!
+            };
+
+            Assert.Throws<Exception>(() => Build(dto));
+        }
+
+        // 7. With display policy present → should NOT throw
+        [Fact]
+        public void CreateGrids_ShouldNotThrow_WhenDisplayPolicyPresent()
+        {
+            var g = Gov("Alex", "", "Test", eLookupGovernorRole.LocalGovernor, null);
+
+            var dto = BuildDto(g);
+
+            var vm = Build(dto);
+
+            Assert.Single(vm.Grids);
+        }
+
+        // 8. Sorting by name
+        [Fact]
+        public void CreateGrids_ShouldSortRowsByName_WhenSortValueNull()
+        {
+            var g1 = Gov("Charlie", "", "Zed", eLookupGovernorRole.LocalGovernor, null);
+            var g2 = Gov("Adam", "", "Baker", eLookupGovernorRole.LocalGovernor, null);
+            var g3 = Gov("Ben", "", "Alpha", eLookupGovernorRole.LocalGovernor, null);
+
+            var dto = BuildDto(g1, g2, g3);
+            var vm = Build(dto);
+
+            var rows = vm.Grids.Single().Rows.Select(r => r.Model.GetFullName()).ToList();
+
+            Assert.Equal(new[] { "Adam Baker", "Ben Alpha", "Charlie Zed" }, rows);
+        }
+
+        // 9. Multi-appointments for same roleId + same URN throws
+        [Fact]
+        public void CreateGrids_ShouldThrow_WhenMultipleAppointmentsForSameUrn()
+        {
+            var g = Gov("Alex", "", "Test", eLookupGovernorRole.LocalGovernor, null);
+
+            g.Appointments = new[]
+            {
+                new GovernorAppointment { EstablishmentUrn = 12345 },
+                new GovernorAppointment { EstablishmentUrn = 12345 } // duplicate URN → should fail
+            };
+
+            var dto = BuildDto(g);
+
+            Assert.Throws<InvalidOperationException>(() => Build(dto));
+        }
+
+        // 10. Correct appointment chosen for shared roles
+        [Fact]
+        public void CreateGrids_ShouldSelectCorrectAppointment_ForSharedRoles()
+        {
+            var g = Gov("Jordan", "", "Scott", eLookupGovernorRole.Group_SharedLocalGovernor, null);
+
+            g.Appointments = new[]
+            {
+                new GovernorAppointment { EstablishmentUrn = 99999, AppointmentStartDate = new DateTime(2020,1,1) },
+                new GovernorAppointment { EstablishmentUrn = 12345, AppointmentStartDate = new DateTime(2021,1,1) }
+            };
+
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>
+            {
+                eLookupGovernorRole.Group_SharedLocalGovernor
+            },
+                CurrentGovernors = new List<GovernorModel> { g },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+            {
+                {
+                    eLookupGovernorRole.Group_SharedLocalGovernor,
+                    new GovernorDisplayPolicy
+                    {
+                        FullName = true,
+                        AppointmentStartDate = true
+                    }
+                }
+            }
+            };
+
+            var vm = Build(dto);
+
+            var row = vm.Grids.Single().Rows.Single();
+
+            var cellTexts = row.Cells.Select(c => c.Text).ToList();
+            Assert.Contains("1 January 2021", cellTexts);
+        }
+
+        // 11. Governance Professional roles produce separate grids
+        [Fact]
+        public void CreateGrids_ShouldCreateSeparateGrids_ForGovernanceProfessionalRoles()
+        {
+            var g1 = Gov("GP1", "", "One", eLookupGovernorRole.GovernanceProfessionalToAMat, null);
+            var g2 = Gov("GP2", "", "Two", eLookupGovernorRole.Group_SharedGovernanceProfessional, null);
+
+            var dto = BuildDto(g1, g2);
+            var vm = Build(dto);
+
+            Assert.Equal(2, vm.Grids.Count);
+        }
+
+        // 12. Governance Professional shared “Shared with” column only for shared GP roles
+        [Fact]
+        public void CreateGrids_ShouldIncludeSharedWithColumn_ForSharedGP()
+        {
+            var g = Gov("Sam", "", "GP", eLookupGovernorRole.Group_SharedGovernanceProfessional, null);
+
+            var dto = BuildDto(g);
+            var vm = Build(dto);
+
+            var headers = vm.Grids.Single().HeaderCells.Select(h => h.Text).ToList();
+
+            Assert.Contains("Shared with", headers);
+        }
+
+        // 13. Non-shared GP roles should NOT show “Shared with”
+        [Fact]
+        public void CreateGrids_ShouldNotIncludeSharedWithColumn_ForNonSharedGP()
+        {
+            var g = Gov("Sam", "", "GP", eLookupGovernorRole.GovernanceProfessionalToAMat, null);
+
+            var dto = BuildDto(g);
+            var vm = Build(dto);
+
+            var headers = vm.Grids.Single().HeaderCells.Select(h => h.Text).ToList();
+
+            Assert.DoesNotContain("Shared with", headers);
+        }
+
+        // 14. Multi-role scenario: no bleed, exactly one grid per roleId
+        [Fact]
+        public void CreateGrids_ShouldCreateOneGridPerRole_NoBleed()
+        {
+            var g1 = Gov("A", "", "Test", eLookupGovernorRole.LocalGovernor, null);
+            var g2 = Gov("B", "", "Test", eLookupGovernorRole.Governor, null);
+            var g3 = Gov("C", "", "Test", eLookupGovernorRole.ChairOfLocalGoverningBody, null);
+
+            var dto = BuildDto(g1, g2, g3);
+            var vm = Build(dto);
+
+            Assert.Equal(3, vm.Grids.Count);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor).Rows);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.Governor).Rows);
+            Assert.Single(vm.Grids.Single(g => g.Role == eLookupGovernorRole.ChairOfLocalGoverningBody).Rows);
         }
 
         private GovernorModel Gov(string first, string middle, string last, eLookupGovernorRole role, DateTime? dob)
@@ -144,7 +287,6 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
                 ApplicableRoles = roles,
                 CurrentGovernors = govs.ToList(),
                 HistoricalGovernors = new List<GovernorModel>(),
-                // Interpretation B: every roleId must have a policy
                 RoleDisplayPolicies = roles.ToDictionary(r => r, _ => new GovernorDisplayPolicy())
             };
         }

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Edubase.Services.Domain;
+using Edubase.Services.Enums;
+using Edubase.Services.Governors.DisplayPolicies;
+using Edubase.Services.Governors.Models;
+using Edubase.Services.Lookup;
+using Edubase.Web.UI.Areas.Governors.Models;
+using Xunit;
+
+namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
+{
+    public class GovernorsGridViewModelTests
+    {
+        private GovernorModel Gov(string first, string last, eLookupGovernorRole role, DateTime dob)
+        {
+            return new GovernorModel
+            {
+                Id = new Random().Next(1000, 9999),
+                Person_FirstName = first,
+                Person_LastName = last,
+                RoleId = (int) role,
+                DOB = dob,
+            };
+        }
+
+        private GovernorsDetailsDto DtoWith(params GovernorModel[] govs)
+        {
+            return new GovernorsDetailsDto
+            {
+                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
+                CurrentGovernors = govs.ToList(),
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = govs
+                    .Select(g => (eLookupGovernorRole) g.RoleId)
+                    .Distinct()
+                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
+            };
+        }
+
+        private GovernorsDetailsDto DtoHistoric(params GovernorModel[] govs)
+        {
+            return new GovernorsDetailsDto
+            {
+                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
+                HistoricalGovernors = govs.ToList(),
+                CurrentGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = govs
+                    .Select(g => (eLookupGovernorRole) g.RoleId)
+                    .Distinct()
+                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
+            };
+        }
+
+        private GovernorsGridViewModel Build(GovernorsDetailsDto dto)
+        {
+            return new GovernorsGridViewModel(
+                dto,
+                editMode: false,
+                groupUId: null,
+                establishmentUrn: 1234,
+                nationalities: Array.Empty<LookupDto>(),
+                appointingBodies: Array.Empty<LookupDto>(),
+                titles: Array.Empty<LookupDto>(),
+                governorPermissions: new GovernorPermissions()
+            );
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldDeduplicateRows_WhenLocalAndSharedRepresentSamePerson()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+            var dto = DtoWith(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
+
+            // Assert
+            Assert.Single(rows);
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldCollapseEquivalentRoles_IntoSingleGrid()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+            var dto = DtoWith(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Single(vm.Grids);  // Only one grid for the role family
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldChooseRepresentativeRole_ThatHasDisplayPolicy()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+            var local = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            var shared = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+
+            var dto = DtoWith(local, shared);
+
+            // Remove the LocalGovernor's policy to force shared-role selection
+            dto.RoleDisplayPolicies.Remove(eLookupGovernorRole.LocalGovernor);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert: the remaining policy is for Group_SharedLocalGovernor
+            Assert.Single(vm.Grids);
+            Assert.Equal(eLookupGovernorRole.Group_SharedLocalGovernor, vm.Grids[0].Role);
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldDeduplicateHistoricGovernors()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
+            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+            var dto = DtoHistoric(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+            var rows = vm.HistoricGrids.SelectMany(g => g.Rows).ToList();
+
+            // Assert
+            Assert.Single(rows);
+        }
+    }
+}

--- a/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Areas/Governors/Models/GovernorsGridViewModelTests.cs
@@ -5,7 +5,6 @@ using Edubase.Services.Domain;
 using Edubase.Services.Enums;
 using Edubase.Services.Governors.DisplayPolicies;
 using Edubase.Services.Governors.Models;
-using Edubase.Services.Lookup;
 using Edubase.Web.UI.Areas.Governors.Models;
 using Xunit;
 
@@ -13,269 +12,167 @@ namespace Edubase.Web.UIUnitTests.Areas.Governors.Models
 {
     public class GovernorsGridViewModelTests
     {
-        private GovernorModel Gov(string first, string last, eLookupGovernorRole role, DateTime dob)
+        [Fact]
+        public void CreateGrids_ShouldNotMergeDifferentRoles_ForSamePerson()
+        {
+            // Arrange
+            var dob = new DateTime(1980, 1, 1);
+            var g1 = Gov("Alex", "J", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+            var g2 = Gov("Alex", "J", "Taylor", eLookupGovernorRole.Establishment_SharedLocalGovernor, dob);
+
+            var dto = BuildDto(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Equal(2, vm.Grids.Count);
+            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
+            Assert.Equal(2, rows.Count);   
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldListAllAppointments_WithinSameRole()
+        {
+            // Arrange
+            var dob = new DateTime(1990, 1, 1);
+            var a1 = Gov("Sam", "", "Morgan", eLookupGovernorRole.LocalGovernor, dob);
+            var a2 = Gov("Sam", "", "Morgan", eLookupGovernorRole.LocalGovernor, dob);
+
+            var dto = BuildDto(a1, a2);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Single(vm.Grids);
+            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
+            Assert.Equal(2, rows.Count);
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldCreateSeparateGrids_ForDistinctRoles()
+        {
+            // Arrange
+            var g1 = Gov("Ava", "", "Singh", eLookupGovernorRole.LocalGovernor, null);
+            var g2 = Gov("Ava", "", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, null);
+
+            var dto = BuildDto(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Equal(2, vm.Grids.Count);
+            Assert.Equal(2, vm.Grids.SelectMany(g => g.Rows).Count());
+        }
+
+        [Fact]
+        public void CreateGrids_ShouldUseExactRoleMatching_NoBleedAcrossGrids()
+        {
+            // Arrange
+            var dob = new DateTime(1985, 5, 5);
+            var shared = Gov("Jamie", "", "Lee", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
+
+            // Intentionally include LocalGovernor in ApplicableRoles to ensure a Local grid is created too.
+            var dto = new GovernorsDetailsDto
+            {
+                ApplicableRoles = new List<eLookupGovernorRole>
+                {
+                    eLookupGovernorRole.LocalGovernor,
+                    eLookupGovernorRole.Group_SharedLocalGovernor
+                },
+                CurrentGovernors = new List<GovernorModel> { shared },
+                HistoricalGovernors = new List<GovernorModel>(),
+                RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
+                {
+                    { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
+                    { eLookupGovernorRole.Group_SharedLocalGovernor, new GovernorDisplayPolicy() }
+                }
+            };
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Equal(2, vm.Grids.Count); // Local + Group_Shared grids
+            var localGrid = vm.Grids.Single(g => g.Role == eLookupGovernorRole.LocalGovernor);
+            var groupGrid = vm.Grids.Single(g => g.Role == eLookupGovernorRole.Group_SharedLocalGovernor);
+
+            Assert.Empty(localGrid.Rows); // exact role matching → no bleed
+            Assert.Single(groupGrid.Rows);
+        }
+
+        [Fact]
+        public void CreateGrids_Historic_ShouldListAllAppointments()
+        {
+            // Arrange
+            var dob = new DateTime(1975, 1, 1);
+            var g1 = Gov("Chris", "", "Walker", eLookupGovernorRole.Governor, dob);
+            var g2 = Gov("Chris", "", "Walker", eLookupGovernorRole.Governor, dob);
+
+            var dto = BuildHistoric(g1, g2);
+
+            // Act
+            var vm = Build(dto);
+
+            // Assert
+            Assert.Single(vm.HistoricGrids);
+            var rows = vm.HistoricGrids.SelectMany(g => g.Rows).ToList();
+            Assert.Equal(2, rows.Count); // NO row dedupe → two historic rows
+        }
+
+        private GovernorModel Gov(string first, string middle, string last, eLookupGovernorRole role, DateTime? dob)
         {
             return new GovernorModel
             {
-                Id = new Random().Next(1000, 9999),
+                Id = new Random().Next(1000, 999999),
                 Person_FirstName = first,
+                Person_MiddleName = middle,
                 Person_LastName = last,
                 RoleId = (int) role,
-                DOB = dob,
+                DOB = dob
             };
         }
 
-        private GovernorsDetailsDto BuildDtoWith(params GovernorModel[] govs)
+        private GovernorsDetailsDto BuildDto(params GovernorModel[] govs)
         {
+            var roles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList();
+
             return new GovernorsDetailsDto
             {
-                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
+                ApplicableRoles = roles,
                 CurrentGovernors = govs.ToList(),
                 HistoricalGovernors = new List<GovernorModel>(),
-                RoleDisplayPolicies = govs
-                    .Select(g => (eLookupGovernorRole) g.RoleId)
-                    .Distinct()
-                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
+                // Interpretation B: every roleId must have a policy
+                RoleDisplayPolicies = roles.ToDictionary(r => r, _ => new GovernorDisplayPolicy())
             };
         }
 
-        private GovernorsDetailsDto DtoWith(params GovernorModel[] govs)
+        private GovernorsDetailsDto BuildHistoric(params GovernorModel[] govs)
         {
-            return new GovernorsDetailsDto
-            {
-                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
-                CurrentGovernors = govs.ToList(),
-                HistoricalGovernors = new List<GovernorModel>(),
-                RoleDisplayPolicies = govs
-                    .Select(g => (eLookupGovernorRole) g.RoleId)
-                    .Distinct()
-                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
-            };
-        }
+            var roles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList();
 
-        // Create a GovernorDetailsDto with historical governors only.
-        private GovernorsDetailsDto DtoHistoric(params GovernorModel[] govs)
-        {
             return new GovernorsDetailsDto
             {
-                ApplicableRoles = govs.Select(g => (eLookupGovernorRole) g.RoleId).Distinct().ToList(),
-                HistoricalGovernors = govs.ToList(),
+                ApplicableRoles = roles,
                 CurrentGovernors = new List<GovernorModel>(),
-                RoleDisplayPolicies = govs
-                    .Select(g => (eLookupGovernorRole) g.RoleId)
-                    .Distinct()
-                    .ToDictionary(r => r, r => new GovernorDisplayPolicy())
+                HistoricalGovernors = govs.ToList(),
+                RoleDisplayPolicies = roles.ToDictionary(r => r, _ => new GovernorDisplayPolicy())
             };
         }
 
-        // Build a fully constructed GovernorGridViewModel with the minimum required inputs.
         private GovernorsGridViewModel Build(GovernorsDetailsDto dto)
         {
             return new GovernorsGridViewModel(
                 dto,
                 editMode: false,
                 groupUId: null,
-                establishmentUrn: 1234,
+                establishmentUrn: 12345,
                 nationalities: Array.Empty<LookupDto>(),
                 appointingBodies: Array.Empty<LookupDto>(),
                 titles: Array.Empty<LookupDto>(),
-                governorPermissions: new GovernorPermissions()
-            );
+                governorPermissions: new GovernorPermissions());
         }
-
-        [Fact]
-        public void CreateGrids_ShouldDeduplicateRows_WhenLocalAndSharedRepresentSamePerson()
-        {
-            // Arrange
-            var dob = new DateTime(1980, 1, 1);
-            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
-            var dto = DtoWith(g1, g2);
-
-            // Act
-            var vm = Build(dto);
-            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
-
-            // Assert
-            Assert.Single(rows);
-        }
-
-        [Fact]
-        public void CreateGrids_ShouldCollapseEquivalentRoles_IntoSingleGrid()
-        {
-            // Arrange
-            var dob = new DateTime(1980, 1, 1);
-            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
-            var dto = DtoWith(g1, g2);
-
-            // Act
-            var vm = Build(dto);
-
-            // Assert
-            Assert.Single(vm.Grids);  // Only one grid for the role family
-        }
-
-        [Fact]
-        public void CreateGrids_ShouldChooseRepresentativeRole_ThatHasDisplayPolicy()
-        {
-            // Arrange
-            var dob = new DateTime(1980, 1, 1);
-            var local = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            var shared = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
-
-            var dto = DtoWith(local, shared);
-
-            // Remove the LocalGovernor's policy to force shared-role selection
-            dto.RoleDisplayPolicies.Remove(eLookupGovernorRole.LocalGovernor);
-
-            // Act
-            var vm = Build(dto);
-
-            // Assert: the remaining policy is for Group_SharedLocalGovernor
-            Assert.Single(vm.Grids);
-            Assert.Equal(eLookupGovernorRole.Group_SharedLocalGovernor, vm.Grids[0].Role);
-        }
-
-        [Fact]
-        public void CreateGrids_ShouldDeduplicateHistoricGovernors()
-        {
-            // Arrange
-            var dob = new DateTime(1980, 1, 1);
-            var g1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            var g2 = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
-            var dto = DtoHistoric(g1, g2);
-
-            // Act
-            var vm = Build(dto);
-            var rows = vm.HistoricGrids.SelectMany(g => g.Rows).ToList();
-
-            // Assert
-            Assert.Single(rows);
-        }
-
-        [Fact]
-        public void CreateGrids_ShouldNotDeduplicate_WhenTwoDifferentPeopleShareSameNameAndDob_DifferentMiddleName()
-        {
-            // Arrange
-            var dob = new DateTime(1980, 1, 1);
-
-            var p1 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            p1.Person_MiddleName = "James";
-            p1.PostCode = "AB1 2CD";
-
-            var p2 = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob);
-            p1.Person_MiddleName = "Marie";
-            p2.PostCode = "XY9 9ZZ";    // Different person
-
-            var dto = BuildDtoWith(p1, p2);
-
-            // Act
-            var vm = Build(dto);
-            var rows = vm.Grids.SelectMany(g => g.Rows).ToList();
-
-            // Assert
-            Assert.Equal(2, rows.Count);
-        }
-
-
-        [Fact]
-        public void LocalGovernorFamily_ShouldCollapseToSingleGrid_AndSingleRow()
-        {
-            var dob = new DateTime(1982, 3, 3);
-
-            var local = Gov("Jamie", "Lee", eLookupGovernorRole.LocalGovernor, dob);
-            var shared = Gov("Jamie", "Lee", eLookupGovernorRole.Group_SharedLocalGovernor, dob);
-
-            var dto = BuildDtoWith(local, shared);
-            var vm = Build(dto);
-
-            Assert.Single(vm.Grids); // role-level dedupe
-            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
-        }
-
-        [Fact]
-        public void ChairFamily_ShouldPickSharedRole_WhenLocalHasNoPolicy()
-        {
-            var dob = new DateTime(1979, 4, 4);
-
-            var chairLocal = Gov("Ava", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, dob);
-            var chairShared = Gov("Ava", "Singh", eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, dob);
-
-            var dto = BuildDtoWith(chairLocal, chairShared);
-
-            // Only shared has policy
-            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
-            {
-                { eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, new GovernorDisplayPolicy() }
-            };
-
-            var vm = Build(dto);
-
-            Assert.Single(vm.Grids);
-            Assert.Equal(eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, vm.Grids[0].Role);
-            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
-        }
-
-        [Fact]
-        public void GovernanceProfessionalFamily_ShouldCollapseToSingleGrid_AndSingleRow()
-        {
-            var dob = new DateTime(1990, 6, 6);
-
-            var gpLocal = Gov("Sam", "Morgan", eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, dob);
-            var gpShared = Gov("Sam", "Morgan", eLookupGovernorRole.Group_SharedGovernanceProfessional, dob);
-
-            var dto = BuildDtoWith(gpLocal, gpShared);
-
-            // Only shared has guaranteed policy
-            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
-            {
-                { eLookupGovernorRole.Group_SharedGovernanceProfessional, new GovernorDisplayPolicy() }
-            };
-
-            var vm = Build(dto);
-
-            Assert.Single(vm.Grids);  // role family merges
-            Assert.Equal(eLookupGovernorRole.Group_SharedGovernanceProfessional, vm.Grids[0].Role);
-            Assert.Single(vm.Grids.SelectMany(g => g.Rows));
-        }
-
-        [Fact]
-        public void MultipleFamilies_ShouldRenderOneGridPerFamily_AndSingleRowPerFamily()
-        {
-            var dob1 = new DateTime(1985, 2, 2);
-            var dob2 = new DateTime(1975, 3, 3);
-            var dob3 = new DateTime(1991, 7, 7);
-
-            // Family 1: Local Gov
-            var gLocal = Gov("Alex", "Taylor", eLookupGovernorRole.LocalGovernor, dob1);
-            var gShared = Gov("Alex", "Taylor", eLookupGovernorRole.Group_SharedLocalGovernor, dob1);
-
-            // Family 2: Chairs
-            var cLocal = Gov("Ava", "Singh", eLookupGovernorRole.ChairOfLocalGoverningBody, dob2);
-            var cShared = Gov("Ava", "Singh", eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, dob2);
-
-            // Family 3: Governance Professional
-            var gpLocal = Gov("Sam", "Morgan", eLookupGovernorRole.GovernanceProfessionalToAnIndividualAcademyOrFreeSchool, dob3);
-            var gpShare = Gov("Sam", "Morgan", eLookupGovernorRole.Group_SharedGovernanceProfessional, dob3);
-
-            var dto = BuildDtoWith(gLocal, gShared, cLocal, cShared, gpLocal, gpShare);
-
-            dto.RoleDisplayPolicies = new Dictionary<eLookupGovernorRole, GovernorDisplayPolicy>
-            {
-                { eLookupGovernorRole.LocalGovernor, new GovernorDisplayPolicy() },
-                { eLookupGovernorRole.Group_SharedChairOfLocalGoverningBody, new GovernorDisplayPolicy() },
-                { eLookupGovernorRole.Group_SharedGovernanceProfessional, new GovernorDisplayPolicy() }
-            };
-
-            var vm = Build(dto);
-
-            // Expect one grid per family → 3 families
-            Assert.Equal(3, vm.Grids.Count);
-
-            // Expect one deduped row per family → 3 rows
-            Assert.Equal(3, vm.Grids.SelectMany(g => g.Rows).Count());
-        }
-
     }
 }


### PR DESCRIPTION
**Overview**
Recent changes in the Java to display historic shared local governors and local governors correctly within an establishment that is part of a trust has resulted in duplicate governors displaying. 
The duplicate governors had the same GID but had different roles due to the governance sharing option being changed.
Investigations came across a role equivalence function which we're not totally certain of its purpose as discussed here: https://dfe-ssp.visualstudio.com/s158-Get-Information-About-Schools/_workitems/edit/300863#11941685
When the sharing option was set to _This establishment shares local governors with other academies in the trust_ then the duplicate would display.
This PR adds some code to catch the duplication and only display the local governor role.

**Major changes**
- `GovernorsGridViewModel` class updated with code to remove the equivalence checks.
- `GovernorGridViewModelTests` class updated with new unit tests.
- `GovernorControllerTests` class updated with a test that originally failed due to displaying 2 roles but after the code change now passes with an assertion on a single role being displayed.

A spike is going to be created for a developer to review and understand the why and what for the _RoleRequivalence_ function.