### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasAdditionalFilters.js
+++ b/Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasAdditionalFilters.js
@@ -1,4 +1,15 @@
 import QueryString from "../GiasHelpers/QueryString";
+
+// Simple HTML-escaping helper to prevent DOM text from being reinterpreted as HTML
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 class GiasAdditionalFilters {
   constructor() {
     this.buildAdditionalFilters();
@@ -11,7 +22,7 @@ class GiasAdditionalFilters {
       return `<div class="govuk-checkboxes__item">
               <input value="#${props.elemId}" data-alias="${props.dataAlias}" id="ctrl-${props.elemId}" class="js-filter-input additional-search-critera govuk-checkboxes__input" type="checkbox">
                 <label for="ctrl-${props.elemId}" class="js-filter-label govuk-label govuk-checkboxes__label">
-                    ${props.text}
+                    ${escapeHtml(props.text)}
                 </label>
             </div>`;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/11](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/11)

In general, the problem is that text read from the DOM is later inserted into an HTML string and passed to `.append()`, which parses it as HTML. To fix this, the text must be HTML-encoded (escape `<`, `>`, `&`, `"`, `'`, etc.) before it is placed in the string template, so that when jQuery interprets the string as HTML the text remains text and cannot break out of the label.

The best minimal fix is to define a small HTML-escaping helper function in `GiasAdditionalFilters.js` and use it when inserting `props.text` into the checkbox template. For example, define `escapeHtml(str)` near the top of the file and change line 14 from `${props.text}` to `${escapeHtml(props.text)}`. This ensures that any meta-characters in `props.text` are safely encoded, while leaving everything else unchanged. We don’t need new dependencies; a short local helper is sufficient and keeps the change confined to the shown code.

Concretely:
- In `Web/Edubase.Web.UI/Assets/Scripts/GiasSearchFilters/GiasAdditionalFilters.js`, add a small `escapeHtml` function above the `GiasAdditionalFilters` class definition.
- Update the `checkBoxTemplate` function so that it uses `escapeHtml(props.text)` instead of `props.text` directly in the label part of the template.
- No other logic (IDs, data attributes, event binding) needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
