### PR TITLE
296879 Potential fix for code scanning alert no. 87: URL redirection from remote source

### DIFF
--- a/Web/Edubase.Web.UI/Controllers/SearchController.cs
+++ b/Web/Edubase.Web.UI/Controllers/SearchController.cs
@@ -252,8 +252,10 @@ namespace Edubase.Web.UI.Controllers
 
                         if (viewModel.SearchType.OneOfThese(eSearchType.Governor, eSearchType.GovernorReference, eSearchType.GovernorAll))
                         {
-                            return Redirect(
-                                $"{Url.Action(ConstIndex, "GovernorSearch", new { area = "Governors" })}?{Request.QueryString}&{string.Join("&", viewModel.GovernorSearchModel.RoleId.Select(r => $"&{Areas.Governors.Models.GovernorSearchViewModel.BIND_ALIAS_ROLE_ID}={r}"))}");
+                            var baseUrl = Url.Action(ConstIndex, "GovernorSearch", new { area = "Governors" });
+                            var roleIdParams = string.Join("&", viewModel.GovernorSearchModel.RoleId.Select(r => $"{Areas.Governors.Models.GovernorSearchViewModel.BIND_ALIAS_ROLE_ID}={r}"));
+                            var redirectUrl = string.IsNullOrEmpty(roleIdParams) ? baseUrl : $"{baseUrl}?{roleIdParams}";
+                            return Redirect(redirectUrl);
                         }
 
                         throw new NotSupportedException($"The search type '{viewModel.SearchType}' is not recognised.");

--- a/Web/Edubase.Web.UI/Controllers/SearchController.cs
+++ b/Web/Edubase.Web.UI/Controllers/SearchController.cs
@@ -15,6 +15,7 @@ using Edubase.Web.UI.Models.Search;
 
 namespace Edubase.Web.UI.Controllers
 {
+    using System.Web;
     using Common.Spatial;
     using Edubase.Services.Geo;
     using eStatus = Services.Enums.eLookupEstablishmentStatus;
@@ -252,9 +253,12 @@ namespace Edubase.Web.UI.Controllers
 
                         if (viewModel.SearchType.OneOfThese(eSearchType.Governor, eSearchType.GovernorReference, eSearchType.GovernorAll))
                         {
-                            var baseUrl = Url.Action(ConstIndex, "GovernorSearch", new { area = "Governors" });
-                            var roleIdParams = string.Join("&", viewModel.GovernorSearchModel.RoleId.Select(r => $"{Areas.Governors.Models.GovernorSearchViewModel.BIND_ALIAS_ROLE_ID}={r}"));
-                            var redirectUrl = string.IsNullOrEmpty(roleIdParams) ? baseUrl : $"{baseUrl}?{roleIdParams}";
+                            string[] allowedKeys = { "SelectedTab", "SearchType", "searchtype", "gsearch", "GovernorSearchModel.Forename", "GovernorSearchModel.Surname", "GovernorSearchModel.RoleId", "GovernorSearchModel.IncludeHistoric", "GovernorSearchModel.Gid" };
+
+                            var qs = CleanQueryString(allowedKeys);
+
+                            var redirectUrl = $"{Url.Action(ConstIndex, "GovernorSearch", new { area = "Governors" })}?{qs}&{string.Join("&", viewModel.GovernorSearchModel.RoleId.Select(r => $"&{Areas.Governors.Models.GovernorSearchViewModel.BIND_ALIAS_ROLE_ID}={r}"))}";
+
                             return Redirect(redirectUrl);
                         }
 
@@ -264,6 +268,29 @@ namespace Edubase.Web.UI.Controllers
             }
 
             return await Index(viewModel);
+        }
+
+        /// <summary>
+        /// Extract an allowed list of query string parameters with the keys contained in allowedKeys.
+        /// </summary>
+        /// <param name="allowedKeys"></param>
+        /// <returns></returns>
+        public string CleanQueryString(string[] allowedKeys)
+        {
+            var cleanQuery = HttpUtility.ParseQueryString(string.Empty);
+
+            foreach (var key in allowedKeys)
+            {
+                var value = Request.QueryString[key];
+                if (value != null)
+                {
+                    cleanQuery[key] = value;
+                }
+            }
+
+            var nqs = cleanQuery.ToString();
+
+            return nqs;
         }
 
         [Route("Suggest"), HttpGet]

--- a/Web/Edubase.Web.UIUnitTests/Controllers/SearchControllerTests.cs
+++ b/Web/Edubase.Web.UIUnitTests/Controllers/SearchControllerTests.cs
@@ -229,7 +229,7 @@ namespace Edubase.Web.UI.Controllers.UnitTests
             var gps = new Mock<IPlacesLookupService>();
 
             var request = new Mock<HttpRequestBase>(MockBehavior.Strict);
-            request.SetupGet(x => x.QueryString).Returns(HttpUtility.ParseQueryString("a=b&c=d&e=f"));
+            request.SetupGet(x => x.QueryString).Returns(HttpUtility.ParseQueryString("SelectedTab=Governors&SearchType=Governor"));
 
             var context = new Mock<HttpContextBase>(MockBehavior.Strict);
             context.SetupGet(x => x.Request).Returns(request.Object);
@@ -241,7 +241,7 @@ namespace Edubase.Web.UI.Controllers.UnitTests
             subject.ControllerContext = new ControllerContext(context.Object, new RouteData(), subject);
             subject.Url = mockUrlHelper.Object;
 
-            const string resultantUrl = "/Governor/Search?a=b&c=d&e=f&";
+            const string resultantUrl = "/Governor/Search?SelectedTab=Governors&SearchType=Governor&";
             var result = await subject.IndexResults(new SearchViewModel { SearchType = eSearchType.Governor }) as RedirectResult;
 
             Assert.NotNull(result);


### PR DESCRIPTION
Potential fix for [https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/87](https://github.com/DFE-Digital/get-information-about-schools/security/code-scanning/87)

In general, to fix untrusted URL redirection issues you must ensure that user input cannot arbitrarily control the redirect target. Here the base path is already fixed, but we still blindly forward the entire query string. The safest fix that preserves existing behavior as much as possible is to stop concatenating `Request.QueryString` directly, and instead rebuild a query string from specific, known-safe parameters on the current request and from the `viewModel`. This way, even if new parameters are added to requests elsewhere, they are not automatically forwarded through this redirect.

Concretely, we will change line 255–256 so that instead of:

```csharp
return Redirect(
    $"{Url.Action(ConstIndex, "GovernorSearch", new { area = "Governors" })}?{Request.QueryString}&{string.Join("&", viewModel.GovernorSearchModel.RoleId.Select(r => $"&{Areas.Governors.Models.GovernorSearchViewModel.BIND_ALIAS_ROLE_ID}={r}"))}");
```

we build a dictionary of allowed query parameters (for example: search terms, paging, filters) by pulling them from `Request.QueryString` by name, and then use an existing helper (if present) or `System.Web.HttpUtility.ParseQueryString` to construct a new query string. Since we are constrained to only modify the shown snippet and imports in this file, and we already see `QueryStringHelper` used elsewhere in the controller, the best fit is to use it to build the query string from selected keys rather than forwarding `Request.QueryString` wholesale. If other parts of the code rely on specific parameters in GovernorSearch, we should include those specific bindings (e.g., from `viewModel.GovernorSearchModel`) rather than an unbounded pass-through.

Because we have not been shown all the relevant parameter names, the minimal safe change that CodeQL will recognize is to remove `Request.QueryString` from the redirect and only include the governor role IDs (which are coming from the server-side model, not directly from the request). This slightly changes behavior by no longer forwarding arbitrary query parameters, but it preserves the primary functional intent of redirecting with the selected governor roles. If needed, additional explicit parameters can be added later using the same controlled pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
